### PR TITLE
FairChemModel Updates: PBC handling, test on OMat24 pre-trained model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest-8-cores, macos-14]
+        os: [ubuntu-latest, macos-14]
         version:
           - { python: "3.11", resolution: highest }
           - { python: "3.12", resolution: lowest-direct }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest-8-cores, macos-14]
         version:
           - { python: "3.11", resolution: highest }
           - { python: "3.12", resolution: lowest-direct }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v2
 
+      - name: Install HuggingFace Hub CLI
+        run: uv pip install huggingface_hub --system
+
       - name: HuggingFace Hub Login
         env:
           HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v2
 
+      - name: HuggingFace Hub Login
+        env:
+          HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+        run: |
+          if [ -n "$HF_TOKEN" ]; then
+            huggingface-cli login --token "$HF_TOKEN"
+          else
+            echo "HF_TOKEN is not set. Skipping login."
+          fi
+
       - name: Install fairchem repository and dependencies
         if: ${{ matrix.model.name == 'fairchem' }}
         run: |

--- a/tests/models/test_fairchem.py
+++ b/tests/models/test_fairchem.py
@@ -66,8 +66,8 @@ test_fairchem_ocp_consistency_pbc = make_model_calculator_consistency_test(
     model_fixture_name="fairchem_model_pbc",
     calculator_fixture_name="ocp_calculator",
     sim_state_names=consistency_test_simstate_fixtures[:-1],
-    rtol=1e-4,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
-    atol=1e-4,
+    rtol=5e-3,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
+    atol=5e-3,
 )
 
 test_fairchem_non_pbc_benzene = make_model_calculator_consistency_test(

--- a/tests/models/test_fairchem.py
+++ b/tests/models/test_fairchem.py
@@ -66,8 +66,8 @@ test_fairchem_ocp_consistency_pbc = make_model_calculator_consistency_test(
     model_fixture_name="fairchem_model_pbc",
     calculator_fixture_name="ocp_calculator",
     sim_state_names=consistency_test_simstate_fixtures[:-1],
-    rtol=5e-4,  # NOTE: EqV2-OC20 doesn't pass at the 1e-5 level used for other models
-    atol=5e-4,
+    rtol=1e-4,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
+    atol=1e-4,
 )
 
 test_fairchem_non_pbc_benzene = make_model_calculator_consistency_test(

--- a/tests/models/test_fairchem.py
+++ b/tests/models/test_fairchem.py
@@ -13,6 +13,7 @@ from tests.models.conftest import (
 try:
     from fairchem.core import OCPCalculator
     from fairchem.core.models.model_registry import model_name_to_local_file
+    from huggingface_hub.utils._auth import get_token
 
     from torch_sim.models.fairchem import FairChemModel
 
@@ -21,24 +22,17 @@ except ImportError:
 
 
 @pytest.fixture(scope="session")
-def model_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+def model_path_oc20(tmp_path_factory: pytest.TempPathFactory) -> str:
     tmp_path = tmp_path_factory.mktemp("fairchem_checkpoints")
-    from huggingface_hub.utils._auth import get_token
-
-    if get_token():
-        # To test OMat24 trained models, you need to set HF_TOKEN env variable.
-        model_name = "EquiformerV2-31M-OMAT24-MP-sAlex"
-    else:
-        model_name = "EquiformerV2-31M-S2EF-OC20-All+MD"
-
+    model_name = "EquiformerV2-31M-S2EF-OC20-All+MD"
     return model_name_to_local_file(model_name, local_cache=str(tmp_path))
 
 
 @pytest.fixture
-def fairchem_model_pbc(model_path: str, device: torch.device) -> FairChemModel:
+def eqv2_oc20_model_pbc(model_path_oc20: str, device: torch.device) -> FairChemModel:
     cpu = device.type == "cpu"
     return FairChemModel(
-        model=model_path,
+        model=model_path_oc20,
         cpu=cpu,
         seed=0,
         pbc=True,
@@ -46,38 +40,60 @@ def fairchem_model_pbc(model_path: str, device: torch.device) -> FairChemModel:
 
 
 @pytest.fixture
-def fairchem_model_non_pbc(model_path: str, device: torch.device) -> FairChemModel:
+def eqv2_oc20_model_non_pbc(model_path_oc20: str, device: torch.device) -> FairChemModel:
     cpu = device.type == "cpu"
     return FairChemModel(
-        model=model_path,
+        model=model_path_oc20,
         cpu=cpu,
         seed=0,
         pbc=False,
     )
 
 
+if get_token():
+
+    @pytest.fixture(scope="session")
+    def model_path_omat24(tmp_path_factory: pytest.TempPathFactory) -> str:
+        tmp_path = tmp_path_factory.mktemp("fairchem_checkpoints")
+        model_name = "EquiformerV2-31M-OMAT24-MP-sAlex"
+        return model_name_to_local_file(model_name, local_cache=str(tmp_path))
+
+    @pytest.fixture
+    def eqv2_omat24_model_pbc(
+        model_path_omat24: str, device: torch.device
+    ) -> FairChemModel:
+        cpu = device.type == "cpu"
+        return FairChemModel(
+            model=model_path_omat24,
+            cpu=cpu,
+            seed=0,
+            pbc=True,
+        )
+
+
 @pytest.fixture
-def ocp_calculator(model_path: str) -> OCPCalculator:
-    return OCPCalculator(checkpoint_path=model_path, cpu=False, seed=0)
+def ocp_calculator(model_path_oc20: str) -> OCPCalculator:
+    return OCPCalculator(checkpoint_path=model_path_oc20, cpu=False, seed=0)
 
 
 test_fairchem_ocp_consistency_pbc = make_model_calculator_consistency_test(
     test_name="fairchem_ocp",
-    model_fixture_name="fairchem_model_pbc",
+    model_fixture_name="eqv2_oc20_model_pbc",
     calculator_fixture_name="ocp_calculator",
     sim_state_names=consistency_test_simstate_fixtures[:-1],
-    rtol=5e-3,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
-    atol=5e-3,
+    rtol=5e-4,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
+    atol=5e-4,
 )
 
 test_fairchem_non_pbc_benzene = make_model_calculator_consistency_test(
     test_name="fairchem_non_pbc_benzene",
-    model_fixture_name="fairchem_model_non_pbc",
+    model_fixture_name="eqv2_oc20_model_non_pbc",
     calculator_fixture_name="ocp_calculator",
     sim_state_names=["benzene_sim_state"],
-    rtol=5e-4,  # NOTE: EqV2-OC20 doesn't pass at the 1e-5 level used for other models
+    rtol=5e-4,  # NOTE: EqV2 doesn't pass at the 1e-5 level used for other models
     atol=5e-4,
 )
+
 
 # Skip this test due to issues with how the older models
 # handled supercells (see related issue here: https://github.com/FAIR-Chem/fairchem/issues/428)
@@ -87,6 +103,6 @@ test_fairchem_ocp_model_outputs = pytest.mark.skipif(
     reason="Issues in graph construction of older models",
 )(
     make_validate_model_outputs_test(
-        model_fixture_name="fairchem_model_pbc",
+        model_fixture_name="eqv2_omat24_model_pbc",
     )
 )

--- a/torch_sim/models/fairchem.py
+++ b/torch_sim/models/fairchem.py
@@ -279,7 +279,7 @@ class FairChemModel(torch.nn.Module, ModelInterface):
 
         if dtype is not None:
             # Convert model parameters to specified dtype
-            self.trainer.model = self.trainer.model.to(dtype=self._dtype)
+            self.trainer.model = self.trainer.model.to(dtype=self.dtype)
 
         if model is not None:
             self.load_checkpoint(checkpoint_path=model, checkpoint=checkpoint)
@@ -374,9 +374,9 @@ class FairChemModel(torch.nn.Module, ModelInterface):
             pbc=pbc,
         )
 
-        if self._dtype is not None:
-            self.data_object.pos = self.data_object.pos.to(self._dtype)
-            self.data_object.cell = self.data_object.cell.to(self._dtype)
+        if self.dtype is not None:
+            self.data_object.pos = self.data_object.pos.to(self.dtype)
+            self.data_object.cell = self.data_object.cell.to(self.dtype)
 
         predictions = self.trainer.predict(
             self.data_object, per_image=False, disable_tqdm=True

--- a/torch_sim/models/graphpes.py
+++ b/torch_sim/models/graphpes.py
@@ -160,9 +160,9 @@ class GraphPESWrapper(torch.nn.Module, ModelInterface):
         self._compute_stress = compute_stress
 
         self._properties: list[PropertyKey] = ["energy"]
-        if self._compute_forces:
+        if self.compute_forces:
             self._properties.append("forces")
-        if self._compute_stress:
+        if self.compute_stress:
             self._properties.append("stress")
 
         if self._gp_model.cutoff.item() < 0.5:

--- a/torch_sim/models/graphpes.py
+++ b/torch_sim/models/graphpes.py
@@ -154,7 +154,7 @@ class GraphPESWrapper(torch.nn.Module, ModelInterface):
                 model if isinstance(model, GraphPESModel) else load_model(model)  # type: ignore[arg-type]
             ),
         )
-        self._gp_model = _model.to(device=self._device, dtype=self._dtype)
+        self._gp_model = _model.to(device=self.device, dtype=self.dtype)
 
         self._compute_forces = compute_forces
         self._compute_stress = compute_stress

--- a/torch_sim/models/lennard_jones.py
+++ b/torch_sim/models/lennard_jones.py
@@ -238,7 +238,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
             results["energies"] = atom_energies
 
-        if self._compute_forces or self._compute_stress:
+        if self.compute_forces or self.compute_stress:
             # Calculate forces and apply cutoff
             pair_forces = lennard_jones_pair_force(
                 distances, sigma=self.sigma, epsilon=self.epsilon
@@ -248,7 +248,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
             # Project forces along displacement vectors
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 # Initialize forces tensor
                 forces = torch.zeros_like(positions)
                 # Add force contributions (f_ij on i, -f_ij on j)
@@ -256,7 +256,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
                 forces.index_add_(0, mapping[1], force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and cell is not None:
+            if self.compute_stress and cell is not None:
                 # Compute stress tensor
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(cell))

--- a/torch_sim/models/lennard_jones.py
+++ b/torch_sim/models/lennard_jones.py
@@ -138,11 +138,9 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
         self.use_neighbor_list = use_neighbor_list
 
         # Convert parameters to tensors
-        self.sigma = torch.tensor(sigma, dtype=dtype, device=self._device)
-        self.cutoff = torch.tensor(
-            cutoff or 2.5 * sigma, dtype=dtype, device=self._device
-        )
-        self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self._device)
+        self.sigma = torch.tensor(sigma, dtype=dtype, device=self.device)
+        self.cutoff = torch.tensor(cutoff or 2.5 * sigma, dtype=dtype, device=self.device)
+        self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self.device)
 
     def unbatched_forward(
         self,
@@ -209,7 +207,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
                 pbc=pbc,
             )
             # Mask out self-interactions
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             # Apply cutoff
             mask = distances < self.cutoff
@@ -233,7 +231,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
 
         if self.per_atom_energies:
             atom_energies = torch.zeros(
-                positions.shape[0], dtype=self._dtype, device=self._device
+                positions.shape[0], dtype=self.dtype, device=self.device
             )
             # Each atom gets half of the pair energy
             atom_energies.index_add_(0, mapping[0], 0.5 * pair_energies)
@@ -268,8 +266,8 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
                 if self.per_atom_stresses:
                     atom_stresses = torch.zeros(
                         (state.positions.shape[0], 3, 3),
-                        dtype=self._dtype,
-                        device=self._device,
+                        dtype=self.dtype,
+                        device=self.device,
                     )
                     atom_stresses.index_add_(0, mapping[0], -0.5 * stress_per_pair)
                     atom_stresses.index_add_(0, mapping[1], -0.5 * stress_per_pair)

--- a/torch_sim/models/mace.py
+++ b/torch_sim/models/mace.py
@@ -160,8 +160,8 @@ class MaceModel(torch.nn.Module, ModelInterface):
         self.model = model.to(self._device)
         self.model = self.model.eval()
 
-        if self._dtype is not None:
-            self.model = self.model.to(dtype=self._dtype)
+        if self.dtype is not None:
+            self.model = self.model.to(dtype=self.dtype)
 
         if enable_cueq:
             print("Converting models to CuEq for acceleration")

--- a/torch_sim/models/mace.py
+++ b/torch_sim/models/mace.py
@@ -334,8 +334,8 @@ class MaceModel(torch.nn.Module, ModelInterface):
                 unit_shifts=unit_shifts,
                 shifts=shifts_list,
             ),
-            compute_force=self._compute_forces,
-            compute_stress=self._compute_stress,
+            compute_force=self.compute_forces,
+            compute_stress=self.compute_stress,
         )
 
         results = {}
@@ -348,13 +348,13 @@ class MaceModel(torch.nn.Module, ModelInterface):
             results["energy"] = torch.zeros(self.n_systems, device=self.device)
 
         # Process forces
-        if self._compute_forces:
+        if self.compute_forces:
             forces = out["forces"]
             if forces is not None:
                 results["forces"] = forces.detach()
 
         # Process stress
-        if self._compute_stress:
+        if self.compute_stress:
             stress = out["stress"]
             if stress is not None:
                 results["stress"] = stress.detach()

--- a/torch_sim/models/mattersim.py
+++ b/torch_sim/models/mattersim.py
@@ -85,8 +85,8 @@ class MatterSimModel(torch.nn.Module, ModelInterface):
         self.model = model.to(self._device)
         self.model = self.model.eval()
 
-        if self._dtype is not None:
-            self.model = self.model.to(dtype=self._dtype)
+        if self.dtype is not None:
+            self.model = self.model.to(dtype=self.dtype)
 
         model_args = self.model.model.model_args
         self.two_body_cutoff = model_args["cutoff"]

--- a/torch_sim/models/morse.py
+++ b/torch_sim/models/morse.py
@@ -142,12 +142,12 @@ class MorseModel(torch.nn.Module, ModelInterface):
         self._per_atom_stresses = per_atom_stresses
         self.use_neighbor_list = use_neighbor_list
         # Convert parameters to tensors
-        self.sigma = torch.tensor(sigma, dtype=self._dtype, device=self._device)
+        self.sigma = torch.tensor(sigma, dtype=self.dtype, device=self.device)
         self.cutoff = torch.tensor(
-            cutoff or 2.5 * sigma, dtype=self._dtype, device=self._device
+            cutoff or 2.5 * sigma, dtype=self.dtype, device=self.device
         )
-        self.epsilon = torch.tensor(epsilon, dtype=self._dtype, device=self._device)
-        self.alpha = torch.tensor(alpha, dtype=self._dtype, device=self._device)
+        self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
+        self.alpha = torch.tensor(alpha, dtype=self.dtype, device=self.device)
 
     def unbatched_forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute Morse potential properties for a single unbatched system.
@@ -205,7 +205,7 @@ class MorseModel(torch.nn.Module, ModelInterface):
                 cell=cell,
                 pbc=pbc,
             )
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             mask = distances < self.cutoff
             i, j = torch.where(mask)
@@ -225,7 +225,7 @@ class MorseModel(torch.nn.Module, ModelInterface):
 
         if self._per_atom_energies:
             atom_energies = torch.zeros(
-                positions.shape[0], dtype=self._dtype, device=self._device
+                positions.shape[0], dtype=self.dtype, device=self.device
             )
             atom_energies.index_add_(0, mapping[0], 0.5 * pair_energies)
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
@@ -254,8 +254,8 @@ class MorseModel(torch.nn.Module, ModelInterface):
                 if self._per_atom_stresses:
                     atom_stresses = torch.zeros(
                         (state.positions.shape[0], 3, 3),
-                        dtype=self._dtype,
-                        device=self._device,
+                        dtype=self.dtype,
+                        device=self.device,
                     )
                     atom_stresses.index_add_(0, mapping[0], -0.5 * stress_per_pair)
                     atom_stresses.index_add_(0, mapping[1], -0.5 * stress_per_pair)

--- a/torch_sim/models/morse.py
+++ b/torch_sim/models/morse.py
@@ -239,13 +239,13 @@ class MorseModel(torch.nn.Module, ModelInterface):
 
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 forces = torch.zeros_like(state.positions)
                 forces.index_add_(0, mapping[0], -force_vectors)
                 forces.index_add_(0, mapping[1], force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and state.cell is not None:
+            if self.compute_stress and state.cell is not None:
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(state.cell))
 

--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -331,8 +331,8 @@ class OrbModel(torch.nn.Module, ModelInterface):
         self.model = model.to(self._device)
         self.model = self.model.eval()
 
-        if self._dtype is not None:
-            self.model = self.model.to(dtype=self._dtype)
+        if self.dtype is not None:
+            self.model = self.model.to(dtype=self.dtype)
 
         # Determine if the model is conservative
         model_is_conservative = hasattr(self.model, "grad_forces_name")
@@ -397,7 +397,7 @@ class OrbModel(torch.nn.Module, ModelInterface):
             max_num_neighbors=self._max_num_neighbors,
             edge_method=self._edge_method,
             half_supercell=half_supercell,
-            device=self._device,
+            device=self.device,
         )
 
         # Run forward pass

--- a/torch_sim/models/sevennet.py
+++ b/torch_sim/models/sevennet.py
@@ -126,8 +126,8 @@ class SevenNetModel(torch.nn.Module, ModelInterface):
         self.model = model.to(self._device)
         self.model = self.model.eval()
 
-        if self._dtype is not None:
-            self.model = self.model.to(dtype=self._dtype)
+        if self.dtype is not None:
+            self.model = self.model.to(dtype=self.dtype)
 
         self.implemented_properties = [
             "energy",

--- a/torch_sim/unbatched/models/lennard_jones.py
+++ b/torch_sim/unbatched/models/lennard_jones.py
@@ -221,7 +221,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
             results["energies"] = atom_energies
 
-        if self._compute_forces or self._compute_stress:
+        if self.compute_forces or self.compute_stress:
             # Calculate forces and apply cutoff
             pair_forces = lennard_jones_pair_force(
                 distances, sigma=self.sigma, epsilon=self.epsilon
@@ -231,7 +231,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
             # Project forces along displacement vectors
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 # Initialize forces tensor
                 forces = torch.zeros_like(positions)
                 # Add force contributions (f_ij on i, -f_ij on j)
@@ -239,7 +239,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
                 forces.index_add_(0, mapping[1], force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and cell is not None:
+            if self.compute_stress and cell is not None:
                 # Compute stress tensor
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(cell))

--- a/torch_sim/unbatched/models/lennard_jones.py
+++ b/torch_sim/unbatched/models/lennard_jones.py
@@ -141,11 +141,9 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
         self.use_neighbor_list = use_neighbor_list
 
         # Convert parameters to tensors
-        self.sigma = torch.tensor(sigma, dtype=dtype, device=self._device)
-        self.cutoff = torch.tensor(
-            cutoff or 2.5 * sigma, dtype=dtype, device=self._device
-        )
-        self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self._device)
+        self.sigma = torch.tensor(sigma, dtype=dtype, device=self.device)
+        self.cutoff = torch.tensor(cutoff or 2.5 * sigma, dtype=dtype, device=self.device)
+        self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self.device)
 
     def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
@@ -192,7 +190,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
                 pbc=pbc,
             )
             # Mask out self-interactions
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             # Apply cutoff
             mask = distances < self.cutoff
@@ -216,7 +214,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
 
         if self._per_atom_energies:
             atom_energies = torch.zeros(
-                positions.shape[0], dtype=self._dtype, device=self._device
+                positions.shape[0], dtype=self.dtype, device=self.device
             )
             # Each atom gets half of the pair energy
             atom_energies.index_add_(0, mapping[0], 0.5 * pair_energies)
@@ -251,8 +249,8 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
                 if self._per_atom_stresses:
                     atom_stresses = torch.zeros(
                         (positions.shape[0], 3, 3),
-                        dtype=self._dtype,
-                        device=self._device,
+                        dtype=self.dtype,
+                        device=self.device,
                     )
                     atom_stresses.index_add_(0, mapping[0], -0.5 * stress_per_pair)
                     atom_stresses.index_add_(0, mapping[1], -0.5 * stress_per_pair)

--- a/torch_sim/unbatched/models/mace.py
+++ b/torch_sim/unbatched/models/mace.py
@@ -226,8 +226,8 @@ class UnbatchedMaceModel(torch.nn.Module, ModelInterface):
                 unit_shifts=shifts_idx,
                 shifts=shifts,
             ),
-            compute_force=self._compute_forces,
-            compute_stress=self._compute_stress,
+            compute_force=self.compute_forces,
+            compute_stress=self.compute_stress,
         )
 
         energy = out["energy"]
@@ -239,11 +239,11 @@ class UnbatchedMaceModel(torch.nn.Module, ModelInterface):
         else:
             results["energy"] = torch.tensor(0.0, device=self.device)
 
-        if self._compute_forces:
+        if self.compute_forces:
             forces = out["forces"]
             results["forces"] = forces
 
-        if self._compute_stress:
+        if self.compute_stress:
             stress = out["stress"].squeeze()
             results["stress"] = stress
 

--- a/torch_sim/unbatched/models/morse.py
+++ b/torch_sim/unbatched/models/morse.py
@@ -133,12 +133,12 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
         self._per_atom_stresses = per_atom_stresses
         self.use_neighbor_list = use_neighbor_list
         # Convert parameters to tensors
-        self.sigma = torch.tensor(sigma, dtype=self._dtype, device=self._device)
+        self.sigma = torch.tensor(sigma, dtype=self.dtype, device=self.device)
         self.cutoff = torch.tensor(
-            cutoff or 2.5 * sigma, dtype=self._dtype, device=self._device
+            cutoff or 2.5 * sigma, dtype=self.dtype, device=self.device
         )
-        self.epsilon = torch.tensor(epsilon, dtype=self._dtype, device=self._device)
-        self.alpha = torch.tensor(alpha, dtype=self._dtype, device=self._device)
+        self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
+        self.alpha = torch.tensor(alpha, dtype=self.dtype, device=self.device)
 
     def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
@@ -180,7 +180,7 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
                 cell=cell,
                 pbc=pbc,
             )
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             mask = distances < self.cutoff
             i, j = torch.where(mask)
@@ -200,7 +200,7 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
 
         if self._per_atom_energies:
             atom_energies = torch.zeros(
-                positions.shape[0], dtype=self._dtype, device=self._device
+                positions.shape[0], dtype=self.dtype, device=self.device
             )
             atom_energies.index_add_(0, mapping[0], 0.5 * pair_energies)
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
@@ -229,8 +229,8 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
                 if self._per_atom_stresses:
                     atom_stresses = torch.zeros(
                         (positions.shape[0], 3, 3),
-                        dtype=self._dtype,
-                        device=self._device,
+                        dtype=self.dtype,
+                        device=self.device,
                     )
                     atom_stresses.index_add_(0, mapping[0], -0.5 * stress_per_pair)
                     atom_stresses.index_add_(0, mapping[1], -0.5 * stress_per_pair)

--- a/torch_sim/unbatched/models/morse.py
+++ b/torch_sim/unbatched/models/morse.py
@@ -214,13 +214,13 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
 
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 forces = torch.zeros_like(positions)
                 forces.index_add_(0, mapping[0], -force_vectors)
                 forces.index_add_(0, mapping[1], force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and cell is not None:
+            if self.compute_stress and cell is not None:
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(cell))
 

--- a/torch_sim/unbatched/models/particle_life.py
+++ b/torch_sim/unbatched/models/particle_life.py
@@ -118,11 +118,11 @@ class UnbatchedParticleLifeModel(torch.nn.Module, ModelInterface):
         self.use_neighbor_list = use_neighbor_list
 
         # Convert parameters to tensors
-        self.sigma = torch.tensor(sigma, dtype=self._dtype, device=self._device)
+        self.sigma = torch.tensor(sigma, dtype=self.dtype, device=self.device)
         self.cutoff = torch.tensor(
-            cutoff or 2.5 * sigma, dtype=self._dtype, device=self._device
+            cutoff or 2.5 * sigma, dtype=self.dtype, device=self.device
         )
-        self.epsilon = torch.tensor(epsilon, dtype=self._dtype, device=self._device)
+        self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
 
     def forward(self, state: SimState) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
@@ -170,7 +170,7 @@ class UnbatchedParticleLifeModel(torch.nn.Module, ModelInterface):
                 pbc=pbc,
             )
             # Mask out self-interactions
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             # Apply cutoff
             mask = distances < self.cutoff

--- a/torch_sim/unbatched/models/soft_sphere.py
+++ b/torch_sim/unbatched/models/soft_sphere.py
@@ -175,7 +175,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
                 pbc=pbc,
             )
             # Remove self-interactions and apply cutoff
-            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self._device)
+            mask = torch.eye(positions.shape[0], dtype=torch.bool, device=self.device)
             distances = distances.masked_fill(mask, float("inf"))
             mask = distances < self.cutoff
 
@@ -196,7 +196,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
         if self._per_atom_energies:
             # Compute per-atom energy contributions
             atom_energies = torch.zeros(
-                positions.shape[0], dtype=self._dtype, device=self._device
+                positions.shape[0], dtype=self.dtype, device=self.device
             )
             # Each atom gets half of the pair energy
             atom_energies.index_add_(0, mapping[0], 0.5 * pair_energies)
@@ -231,8 +231,8 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
                     # Compute per-atom stress contributions
                     atom_stresses = torch.zeros(
                         (positions.shape[0], 3, 3),
-                        dtype=self._dtype,
-                        device=self._device,
+                        dtype=self.dtype,
+                        device=self.device,
                     )
                     atom_stresses.index_add_(0, mapping[0], -0.5 * stress_per_pair)
                     atom_stresses.index_add_(0, mapping[1], -0.5 * stress_per_pair)

--- a/torch_sim/unbatched/models/soft_sphere.py
+++ b/torch_sim/unbatched/models/soft_sphere.py
@@ -203,7 +203,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
             results["energies"] = atom_energies
 
-        if self._compute_forces or self._compute_stress:
+        if self.compute_forces or self.compute_stress:
             # Calculate pair forces
             pair_forces = soft_sphere_pair_force(
                 distances, sigma=self.sigma, epsilon=self.epsilon, alpha=self.alpha
@@ -212,7 +212,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
             # Project scalar forces onto displacement vectors
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 # Compute atomic forces by accumulating pair contributions
                 forces = torch.zeros_like(positions)
                 # Add force contributions (f_ij on j, -f_ij on i)
@@ -220,7 +220,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
                 forces.index_add_(0, mapping[1], -force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and cell is not None:
+            if self.compute_stress and cell is not None:
                 # Compute stress tensor using virial formula
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(cell))
@@ -244,7 +244,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
 # TODO: Standardize the interface for multi-species models
 
 
-class UnbatchedSoftSphereMultiModel(torch.nn.Module):
+class UnbatchedSoftSphereMultiModel(torch.nn.Module, ModelInterface):
     """Calculator for soft sphere potential with multiple atomic species.
 
     This model implements a multi-species soft sphere potential where the interaction
@@ -462,7 +462,7 @@ class UnbatchedSoftSphereMultiModel(torch.nn.Module):
             atom_energies.index_add_(0, mapping[1], 0.5 * pair_energies)
             results["energies"] = atom_energies
 
-        if self._compute_forces or self._compute_stress:
+        if self.compute_forces or self.compute_stress:
             # Calculate pair forces
             pair_forces = soft_sphere_pair_force(
                 distances, sigma=pair_sigmas, epsilon=pair_epsilons, alpha=pair_alphas
@@ -471,7 +471,7 @@ class UnbatchedSoftSphereMultiModel(torch.nn.Module):
             # Project scalar forces onto displacement vectors
             force_vectors = (pair_forces / distances)[:, None] * dr_vec
 
-            if self._compute_forces:
+            if self.compute_forces:
                 # Compute atomic forces by accumulating pair contributions
                 forces = torch.zeros_like(positions)
                 # Add force contributions (f_ij on j, -f_ij on i)
@@ -479,7 +479,7 @@ class UnbatchedSoftSphereMultiModel(torch.nn.Module):
                 forces.index_add_(0, mapping[1], -force_vectors)
                 results["forces"] = forces
 
-            if self._compute_stress and cell is not None:
+            if self.compute_stress and cell is not None:
                 # Compute stress tensor using virial formula
                 stress_per_pair = torch.einsum("...i,...j->...ij", dr_vec, force_vectors)
                 volume = torch.abs(torch.linalg.det(cell))


### PR DESCRIPTION
## Summary

- [x] Fixes https://github.com/Radical-AI/torch-sim/issues/111 
- [x] Add tests with OMat24 pre-trained model if HF_TOKEN env is set

Will include tests with OMat models as in [quacc](https://github.com/Quantum-Accelerators/quacc) in the next PR.

## Checklist

* [x] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.


