### PR TITLE
Pad memory estimation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,9 @@ Before a pull request can be merged, the following items must be checked:
 * [ ] Tests have been added for any new functionality or bug fixes.
 * [ ] All linting and tests pass.
 
+<!-- 
 Note that the CI system will run all the above checks. But it will be much more
 efficient if you already fix most errors prior to submitting the PR. It is highly
 recommended that you use the pre-commit hook provided in the repository. Simply run
 `pre-commit install` and a check will be run prior to allowing commits.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Before a pull request can be merged, the following items must be checked:
 * [ ] Tests have been added for any new functionality or bug fixes.
 * [ ] All linting and tests pass.
 
-<!-- 
+<!--
 Note that the CI system will run all the above checks. But it will be much more
 efficient if you already fix most errors prior to submitting the PR. It is highly
 recommended that you use the pre-commit hook provided in the repository. Simply run

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ docs/reference/torch_sim.*
 # coverage
 coverage.xml
 .coverage
+
+# env
+uv.lock

--- a/tests/models/test_mace.py
+++ b/tests/models/test_mace.py
@@ -15,7 +15,7 @@ try:
     from mace.calculators.foundations_models import mace_mp, mace_off
 
     from torch_sim.models.mace import MaceModel
-except ImportError:
+except (ImportError, ValueError):
     pytest.skip("MACE not installed", allow_module_level=True)
 
 

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -173,7 +173,7 @@ def test_binning_auto_batcher_auto_metric(
     # monkeypath determine max memory scaler
     monkeypatch.setattr(
         "torch_sim.autobatching.determine_max_batch_size",
-        lambda *args, **kwargs: 50,
+        lambda *args, **kwargs: 50,  # noqa: ARG005
     )
 
     # Create a list of states with different sizes

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -163,6 +163,53 @@ def test_binning_auto_batcher(
     assert torch.all(restored_states[1].atomic_numbers == states[1].atomic_numbers)
 
 
+def test_binning_auto_batcher_auto_metric(
+    si_sim_state: SimState,
+    fe_supercell_sim_state: SimState,
+    lj_model: LennardJonesModel,
+    monkeypatch: Any,
+) -> None:
+    """Test BinningAutoBatcher with different states."""
+    # monkeypath determine max memory scaler
+    monkeypatch.setattr(
+        "torch_sim.autobatching.determine_max_batch_size",
+        lambda *args, **kwargs: 50,
+    )
+
+    # Create a list of states with different sizes
+    states = [si_sim_state, fe_supercell_sim_state]
+
+    # Initialize the batcher with a fixed max_metric to avoid GPU memory testing
+    batcher = BinningAutoBatcher(
+        model=lj_model,
+        memory_scales_with="n_atoms",
+    )
+    batcher.load_states(states)
+
+    # Check that the batcher correctly identified the metrics
+    assert len(batcher.memory_scalers) == 2
+    assert batcher.memory_scalers[0] == si_sim_state.n_atoms
+    assert batcher.memory_scalers[1] == fe_supercell_sim_state.n_atoms
+
+    # Get batches until None is returned
+    batches = list(batcher)
+
+    # Check we got the expected number of batches
+    assert len(batches) == len(batcher.batched_states)
+
+    # Test restore_original_order
+    restored_states = batcher.restore_original_order(batches)
+    assert len(restored_states) == len(states)
+
+    # Check that the restored states match the original states in order
+    assert restored_states[0].n_atoms == states[0].n_atoms
+    assert restored_states[1].n_atoms == states[1].n_atoms
+
+    # Check atomic numbers to verify the correct order
+    assert torch.all(restored_states[0].atomic_numbers == states[0].atomic_numbers)
+    assert torch.all(restored_states[1].atomic_numbers == states[1].atomic_numbers)
+
+
 def test_binning_auto_batcher_with_indices(
     si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
 ) -> None:

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -463,6 +463,7 @@ class BinningAutoBatcher:
         return_indices: bool = False,
         max_atoms_to_try: int = 500_000,
         memory_scaling_factor: float = 1.6,
+        max_memory_padding: float = 1.0,
     ) -> None:
         """Initialize the binning auto-batcher.
 
@@ -484,6 +485,8 @@ class BinningAutoBatcher:
                 iteration. Larger values will get a batch size more quickly, smaller
                 values will get a more accurate limit. Must be greater than 1. Defaults
                 to 1.6.
+            max_memory_padding (float): Multiply the autodetermined max_memory_scaler
+                by this value to account for fluctuations in max memory. Defaults to 1.0.
         """
         self.max_memory_scaler = max_memory_scaler
         self.max_atoms_to_try = max_atoms_to_try
@@ -491,6 +494,7 @@ class BinningAutoBatcher:
         self.return_indices = return_indices
         self.model = model
         self.memory_scaling_factor = memory_scaling_factor
+        self.max_memory_padding = max_memory_padding
 
     def load_states(
         self,
@@ -540,6 +544,7 @@ class BinningAutoBatcher:
                 max_atoms=self.max_atoms_to_try,
                 scale_factor=self.memory_scaling_factor,
             )
+            self.max_memory_scaler += self.max_memory_padding
         else:
             self.max_memory_scaler = self.max_memory_scaler
 
@@ -758,6 +763,7 @@ class InFlightAutoBatcher:
         memory_scaling_factor: float = 1.6,
         return_indices: bool = False,
         max_iterations: int | None = None,
+        max_memory_padding: float = 1.0,
     ) -> None:
         """Initialize the hot-swapping auto-batcher.
 
@@ -782,6 +788,8 @@ class InFlightAutoBatcher:
             max_iterations (int | None): Maximum number of iterations to process a state
                 before considering it complete, regardless of convergence. Used to prevent
                 infinite loops. Defaults to None (no limit).
+            max_memory_padding (float): Multiply the autodetermined max_memory_scaler
+                by this value to account for fluctuations in max memory. Defaults to 1.0.
         """
         self.model = model
         self.memory_scales_with = memory_scales_with
@@ -790,6 +798,7 @@ class InFlightAutoBatcher:
         self.memory_scaling_factor = memory_scaling_factor
         self.return_indices = return_indices
         self.max_attempts = max_iterations  # TODO: change to max_iterations
+        self.max_memory_padding = max_memory_padding
 
     def load_states(
         self,
@@ -942,6 +951,7 @@ class InFlightAutoBatcher:
                 max_atoms=self.max_atoms_to_try,
                 scale_factor=self.memory_scaling_factor,
             )
+            self.max_memory_scaler += self.max_memory_padding
             print(f"Max metric calculated: {self.max_memory_scaler}")
         return concatenate_states([first_state, *states])
 

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -544,9 +544,7 @@ class BinningAutoBatcher:
                 max_atoms=self.max_atoms_to_try,
                 scale_factor=self.memory_scaling_factor,
             )
-            self.max_memory_scaler += self.max_memory_padding
-        else:
-            self.max_memory_scaler = self.max_memory_scaler
+            self.max_memory_scaler = self.max_memory_scaler * self.max_memory_padding
 
         # verify that no systems are too large
         max_metric_value = max(self.memory_scalers)
@@ -951,7 +949,7 @@ class InFlightAutoBatcher:
                 max_atoms=self.max_atoms_to_try,
                 scale_factor=self.memory_scaling_factor,
             )
-            self.max_memory_scaler += self.max_memory_padding
+            self.max_memory_scaler *= self.max_memory_padding
             print(f"Max metric calculated: {self.max_memory_scaler}")
         return concatenate_states([first_state, *states])
 

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -949,7 +949,7 @@ class InFlightAutoBatcher:
                 max_atoms=self.max_atoms_to_try,
                 scale_factor=self.memory_scaling_factor,
             )
-            self.max_memory_scaler *= self.max_memory_padding
+            self.max_memory_scaler = self.max_memory_scaler * self.max_memory_padding
             print(f"Max metric calculated: {self.max_memory_scaler}")
         return concatenate_states([first_state, *states])
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -77,6 +77,7 @@ def _configure_batches_iterator(
         autobatcher = BinningAutoBatcher(
             model=model,
             return_indices=True,
+            max_memory_padding=0.9,
         )
         autobatcher.load_states(state)
         batches = autobatcher
@@ -219,6 +220,7 @@ def _configure_in_flight_autobatcher(
             max_memory_scaler=max_memory_scaler,
             memory_scales_with=memory_scales_with,
             max_iterations=max_attempts,
+            max_memory_padding=0.9,
         )
     return autobatcher
 


### PR DESCRIPTION
## Summary

Pads max memory estimation by 0.9 to prevent running out of memory due to memory fluctuations. Probable fix for issue #159.

## Checklist

<!-- Work-in-progress pull requests are encouraged, but please enable the draft status on your PR. -->

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.
