### PR TITLE
Updates integrator logic per #171. 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,37 @@ def rattled_sio2_sim_state(
 
 
 @pytest.fixture
+def casio3_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+    a, b, c = 7.9258, 7.3202, 7.0653
+    alpha, beta, gamma = 90.055, 95.217, 103.426
+    symbols = ["Ca"] * 3 + ["Si"] * 3 + ["O"] * 9
+    basis = [
+        (0.19831, 0.42266, 0.76060),  # Ca
+        (0.20241, 0.92919, 0.76401),  # Ca
+        (0.50333, 0.75040, 0.52691),  # Ca
+        (0.1851, 0.3875, 0.2684),  # Si
+        (0.1849, 0.9542, 0.2691),  # Si
+        (0.3973, 0.7236, 0.0561),  # Si
+        (0.3034, 0.4616, 0.4628),  # O
+        (0.3014, 0.9385, 0.4641),  # O
+        (0.5705, 0.7688, 0.1988),  # O
+        (0.9832, 0.3739, 0.2655),  # O
+        (0.9819, 0.8677, 0.2648),  # O
+        (0.4018, 0.7266, 0.8296),  # O
+        (0.2183, 0.1785, 0.2254),  # O
+        (0.2713, 0.8704, 0.0938),  # O
+        (0.2735, 0.5126, 0.0931),  # O
+    ]
+    atoms = crystal(
+        symbols,
+        basis=basis,
+        spacegroup=2,
+        cellpar=[a, b, c, alpha, beta, gamma],
+    )
+    return ts.io.atoms_to_state(atoms, device, dtype)
+
+
+@pytest.fixture
 def benzene_sim_state(
     benzene_atoms: Any, device: torch.device, dtype: torch.dtype
 ) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,14 +127,10 @@ def ti_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 def tio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
     """Create crystalline TiO2 using ASE."""
     a, c = 4.60, 2.96
-    symbols = ["Ti", "O", "O"]
-    basis = [
-        (0.5, 0.5, 0),  # Ti
-        (0.695679, 0.695679, 0.5),  # O
-    ]
+    basis = [("Ti", 0.5, 0.5, 0), ("O", 0.695679, 0.695679, 0.5)]
     atoms = crystal(
-        symbols,
-        basis=basis,
+        symbols=[b[0] for b in basis],
+        basis=[b[1:] for b in basis],
         spacegroup=136,  # P4_2/mnm
         cellpar=[a, a, c, 90, 90, 90],
     )
@@ -145,13 +141,10 @@ def tio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 def ga_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
     """Create crystalline Ga using ASE."""
     a, b, c = 4.43, 7.60, 4.56
-    symbols = ["Ga"]
-    basis = [
-        (0, 0.344304, 0.415401),  # Ga
-    ]
+    basis = [("Ga", 0, 0.344304, 0.415401)]
     atoms = crystal(
-        symbols,
-        basis=basis,
+        symbols=[b[0] for b in basis],
+        basis=[b[1:] for b in basis],
         spacegroup=64,  # Cmce
         cellpar=[a, b, c, 90, 90, 90],
     )
@@ -163,14 +156,13 @@ def niti_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
     """Create crystalline NiTi using ASE."""
     a, b, c = 2.89, 3.97, 4.83
     alpha, beta, gamma = 90.00, 105.23, 90.00
-    symbols = ["Ni", "Ti"]
     basis = [
-        (0.369548, 0.25, 0.217074),  # Ni
-        (0.076622, 0.25, 0.671102),  # Ti
+        ("Ni", 0.369548, 0.25, 0.217074),
+        ("Ti", 0.076622, 0.25, 0.671102),
     ]
     atoms = crystal(
-        symbols,
-        basis=basis,
+        symbols=[b[0] for b in basis],
+        basis=[b[1:] for b in basis],
         spacegroup=11,
         cellpar=[a, b, c, alpha, beta, gamma],
     )
@@ -219,27 +211,26 @@ def rattled_sio2_sim_state(
 def casio3_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
     a, b, c = 7.9258, 7.3202, 7.0653
     alpha, beta, gamma = 90.055, 95.217, 103.426
-    symbols = ["Ca"] * 3 + ["Si"] * 3 + ["O"] * 9
     basis = [
-        (0.19831, 0.42266, 0.76060),  # Ca
-        (0.20241, 0.92919, 0.76401),  # Ca
-        (0.50333, 0.75040, 0.52691),  # Ca
-        (0.1851, 0.3875, 0.2684),  # Si
-        (0.1849, 0.9542, 0.2691),  # Si
-        (0.3973, 0.7236, 0.0561),  # Si
-        (0.3034, 0.4616, 0.4628),  # O
-        (0.3014, 0.9385, 0.4641),  # O
-        (0.5705, 0.7688, 0.1988),  # O
-        (0.9832, 0.3739, 0.2655),  # O
-        (0.9819, 0.8677, 0.2648),  # O
-        (0.4018, 0.7266, 0.8296),  # O
-        (0.2183, 0.1785, 0.2254),  # O
-        (0.2713, 0.8704, 0.0938),  # O
-        (0.2735, 0.5126, 0.0931),  # O
+        ("Ca", 0.19831, 0.42266, 0.76060),
+        ("Ca", 0.20241, 0.92919, 0.76401),
+        ("Ca", 0.50333, 0.75040, 0.52691),
+        ("Si", 0.1851, 0.3875, 0.2684),
+        ("Si", 0.1849, 0.9542, 0.2691),
+        ("Si", 0.3973, 0.7236, 0.0561),
+        ("O", 0.3034, 0.4616, 0.4628),
+        ("O", 0.3014, 0.9385, 0.4641),
+        ("O", 0.5705, 0.7688, 0.1988),
+        ("O", 0.9832, 0.3739, 0.2655),
+        ("O", 0.9819, 0.8677, 0.2648),
+        ("O", 0.4018, 0.7266, 0.8296),
+        ("O", 0.2183, 0.1785, 0.2254),
+        ("O", 0.2713, 0.8704, 0.0938),
+        ("O", 0.2735, 0.5126, 0.0931),
     ]
     atoms = crystal(
-        symbols,
-        basis=basis,
+        symbols=[b[0] for b in basis],
+        basis=[b[1:] for b in basis],
         spacegroup=2,
         cellpar=[a, b, c, alpha, beta, gamma],
     )

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -27,6 +27,7 @@ consistency_test_simstate_fixtures: Final[tuple[str, ...]] = (
     "rattled_sio2_sim_state",
     "ar_supercell_sim_state",
     "fe_supercell_sim_state",
+    "casio3_sim_state",
     "benzene_sim_state",
 )
 

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -362,13 +362,13 @@ def test_compare_single_vs_batched_integrators(
     # Compare single state results with each part of the batched state
     for final_state in [batched_state_0, batched_state_1]:
         # Check positions first - most likely to fail with incorrect PBC
-        assert torch.allclose(single_state.positions, final_state.positions)
+        torch.testing.assert_close(single_state.positions, final_state.positions)
         # Check other state components
-        assert torch.allclose(single_state.momenta, final_state.momenta)
-        assert torch.allclose(single_state.forces, final_state.forces)
-        assert torch.allclose(single_state.masses, final_state.masses)
-        assert torch.allclose(single_state.cell, final_state.cell)
-        assert torch.allclose(single_state.energy, final_state.energy)
+        torch.testing.assert_close(single_state.momenta, final_state.momenta)
+        torch.testing.assert_close(single_state.forces, final_state.forces)
+        torch.testing.assert_close(single_state.masses, final_state.masses)
+        torch.testing.assert_close(single_state.cell, final_state.cell)
+        torch.testing.assert_close(single_state.energy, final_state.energy)
 
 
 def test_compute_cell_force_atoms_per_batch():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -98,38 +98,17 @@ def test_pbc_wrap_general_orthorhombic() -> None:
     ("cell", "shift"),
     [
         # Cubic cell, integer shift [1, 1, 1]
-        (
-            torch.eye(3, dtype=torch.float64) * 2.0,
-            torch.tensor([1, 1, 1], dtype=torch.float64),
-        ),
+        (torch.eye(3, dtype=torch.float64) * 2.0, [1, 1, 1]),
         # Triclinic cell, integer shift [1, 1, 1]
-        (
-            torch.tensor(
-                [
-                    [2.0, 0.5, 0.0],
-                    [0.0, 2.0, 0.0],
-                    [0.0, 0.3, 2.0],
-                ],
-                dtype=torch.float64,
-            ).T,
-            torch.tensor([1, 1, 1], dtype=torch.float64),
-        ),
+        (([[2.0, 0.0, 0.0], [0.5, 2.0, 0.0], [0.0, 0.3, 2.0]]), [1, 1, 1]),
         # Triclinic cell, integer shift [-1, 2, 0]
-        (
-            torch.tensor(
-                [
-                    [2.0, 0.5, 0.0],
-                    [0.0, 2.0, 0.0],
-                    [0.0, 0.3, 2.0],
-                ],
-                dtype=torch.float64,
-            ).T,
-            torch.tensor([-1, 2, 0], dtype=torch.float64),
-        ),
+        (([[2.0, 0.5, 0.0], [0.0, 2.0, 0.0], [0.0, 0.3, 2.0]]), [-1, 2, 0]),
     ],
 )
 def test_pbc_wrap_general_param(cell: torch.Tensor, shift: torch.Tensor) -> None:
     """Test periodic boundary wrapping for various cells and integer shifts."""
+    cell = torch.as_tensor(cell, dtype=torch.float64)
+    shift = torch.as_tensor(shift, dtype=torch.float64)
     base_frac = torch.tensor([[0.25, 0.5, 0.75]], dtype=torch.float64)
     base_cart = base_frac @ cell.T
     shifted_cart = base_cart + (shift @ cell.T)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,6 +103,14 @@ def test_pbc_wrap_general_orthorhombic() -> None:
         (([[2.0, 0.0, 0.0], [0.5, 2.0, 0.0], [0.0, 0.3, 2.0]]), [1, 1, 1]),
         # Triclinic cell, integer shift [-1, 2, 0]
         (([[2.0, 0.5, 0.0], [0.0, 2.0, 0.0], [0.0, 0.3, 2.0]]), [-1, 2, 0]),
+        # triclinic, all negative shift
+        (([[2.0, 0.5, 0.0], [0.0, 2.0, 0.0], [0.0, 0.3, 2.0]]), [-2, -1, -3]),
+        # cubic, large mixed shift
+        (torch.eye(3, dtype=torch.float64) * 2.0, [5, 0, -10]),
+        # highly tilted cell
+        (([[1.3, 0.9, 0.8], [0.0, 1.0, 0.9], [0.0, 0.0, 1.0]]), [1, -2, 3]),
+        # Left-handed cell
+        (([[2.0, 0.0, 0.0], [0.0, -2.0, 0.0], [0.0, 0.0, 2.0]]), [1, 1, 1]),
     ],
 )
 def test_pbc_wrap_general_param(cell: torch.Tensor, shift: torch.Tensor) -> None:

--- a/torch_sim/integrators.py
+++ b/torch_sim/integrators.py
@@ -168,9 +168,7 @@ def position_step(state: MDState, dt: torch.Tensor) -> MDState:
 
     if state.pbc:
         # Split positions and cells by batch
-        new_positions = pbc_wrap_batched(
-            new_positions, state.cell.swapaxes(1, 2), state.batch
-        )
+        new_positions = pbc_wrap_batched(new_positions, state.cell, state.batch)
 
     state.positions = new_positions
     return state
@@ -1027,9 +1025,7 @@ def npt_langevin(  # noqa: C901, PLR0915
 
         # Apply periodic boundary conditions if needed
         if state.pbc:
-            state.positions = pbc_wrap_batched(
-                state.positions, state.cell.swapaxes(1, 2), state.batch
-            )
+            state.positions = pbc_wrap_batched(state.positions, state.cell, state.batch)
 
         return state
 

--- a/torch_sim/transforms.py
+++ b/torch_sim/transforms.py
@@ -105,8 +105,8 @@ def pbc_wrap_general(
     Args:
         positions (torch.Tensor): Tensor of shape (..., d)
             containing particle positions in real space.
-        lattice_vectors (torch.Tensor): Tensor of shape (d, d)
-            containing lattice vectors as columns (A matrix in the equations).
+        lattice_vectors (torch.Tensor): Tensor of shape (d, d) containing
+            lattice vectors as columns (A matrix in the equations).
 
     Returns:
         torch.Tensor: Tensor of wrapped positions in real space with
@@ -181,15 +181,8 @@ def pbc_wrap_batched(
     # For each atom, multiply its position by its batch's inverse cell matrix
     frac_coords = torch.bmm(B_per_atom, positions.unsqueeze(2)).squeeze(2)
 
-    # Wrap to reference cell [0,1) using f - floor(f)
-    wrapped_frac = frac_coords - torch.floor(frac_coords)
-
-    # Handle edge case of positions exactly on upper boundary
-    wrapped_frac = torch.where(
-        torch.isclose(wrapped_frac, torch.ones_like(wrapped_frac)),
-        torch.zeros_like(wrapped_frac),
-        wrapped_frac,
-    )
+    # Wrap to reference cell [0,1) using modulo
+    wrapped_frac = frac_coords % 1.0
 
     # Transform back to real space: r = A·f
     # Get the cell for each atom based on its batch index

--- a/torch_sim/transforms.py
+++ b/torch_sim/transforms.py
@@ -93,24 +93,24 @@ def inverse_box(box: torch.Tensor) -> torch.Tensor:
 def pbc_wrap_general(
     positions: torch.Tensor, lattice_vectors: torch.Tensor
 ) -> torch.Tensor:
-    """Apply periodic boundary conditions using lattice vector transformation.
+    """Apply periodic boundary conditions using lattice
+        vector transformation method.
 
-    Assumes positions are row vectors and the lattice_vectors matrix has
-    **row vectors** (M_row convention), where rows correspond to lattice vectors a, b, c.
-
-    Formula:
-    f_row = r_row @ inv(M_row.T)
-    wrapped_f_row = f_row % 1.0
-    r_row_wrapped = wrapped_f_row @ M_row
+    This implementation follows the general matrix-based approach for
+    periodic boundary conditions in arbitrary triclinic cells:
+    1. Transform positions to fractional coordinates using B = A^(-1)
+    2. Wrap fractional coordinates to [0,1) using modulo
+    3. Transform back to real space using A
 
     Args:
         positions (torch.Tensor): Tensor of shape (..., d)
-            containing particle positions as row vectors (r_row).
+            containing particle positions in real space.
         lattice_vectors (torch.Tensor): Tensor of shape (d, d)
-            containing lattice vectors as column vectors.
+            containing lattice vectors as columns (A matrix in the equations).
 
     Returns:
-        torch.Tensor: Tensor of wrapped positions in real space as row vectors (r_row').
+        torch.Tensor: Tensor of wrapped positions in real space with
+            same shape as input positions.
     """
     # Validate inputs
     if not torch.is_floating_point(positions) or not torch.is_floating_point(
@@ -119,16 +119,13 @@ def pbc_wrap_general(
         raise TypeError("Positions and lattice vectors must be floating point tensors.")
 
     if lattice_vectors.ndim != 2 or lattice_vectors.shape[0] != lattice_vectors.shape[1]:
-        raise ValueError("Lattice vectors must be a square matrix (d, d).")
+        raise ValueError("Lattice vectors must be a square matrix.")
 
     if positions.shape[-1] != lattice_vectors.shape[0]:
         raise ValueError("Position dimensionality must match lattice vectors.")
 
-    # Compute inv(M_row.T)
-    inv_lattice_vectors_T = torch.linalg.inv(lattice_vectors.T)
-
-    # Transform to fractional coordinates: f_row = r_row @ inv(M_row.T)
-    frac_coords = positions @ inv_lattice_vectors_T
+    # Transform to fractional coordinates: f = Br
+    frac_coords = positions @ torch.linalg.inv(lattice_vectors).T
 
     # Wrap to reference cell [0,1) using modulo
     wrapped_frac = frac_coords % 1.0
@@ -142,21 +139,21 @@ def pbc_wrap_batched(
 ) -> torch.Tensor:
     """Apply periodic boundary conditions to batched systems.
 
-    Handles wrapping positions for multiple systems (batches). Assumes the
-    input cell matrix contains lattice vectors as **rows** and input
-    positions are **row vectors**.
+    This function handles wrapping positions for multiple atomistic systems
+    (batches) in one operation. It uses the batch indices to determine which
+    atoms belong to which system and applies the appropriate cell vectors.
 
     Args:
         positions (torch.Tensor): Tensor of shape (n_atoms, 3) containing
-            particle positions as **row vectors**.
+            particle positions in real space.
         cell (torch.Tensor): Tensor of shape (n_batches, 3, 3) containing
             lattice vectors as column vectors.
         batch (torch.Tensor): Tensor of shape (n_atoms,) containing batch
             indices for each atom.
 
     Returns:
-        torch.Tensor: Tensor of wrapped positions in real space as **row vectors**
-            with shape (n_atoms, 3).
+        torch.Tensor: Tensor of wrapped positions in real space with
+            same shape as input positions.
     """
     # Validate inputs
     if not torch.is_floating_point(positions) or not torch.is_floating_point(cell):
@@ -176,36 +173,30 @@ def pbc_wrap_batched(
         )
 
     # Efficient approach without explicit loops
+    # Get the cell for each atom based on its batch index
+    B = torch.linalg.inv(cell)  # Shape: (n_batches, 3, 3)
+    B_per_atom = B[batch]  # Shape: (n_atoms, 3, 3)
 
-    # Calculate inverse transpose of cell: inv(M_row.T)
-    # Need M_col = M_row.T for fractional calculation convention
-    # inv_cell_T = torch.linalg.inv(cell.mT) # Fails for non-batched? Needs checking.
-    # Alternative: compute inv(M_row) first, then transpose.
-    inv_cell = torch.linalg.inv(cell)  # inv(M_row)
-    inv_cell_T = inv_cell.mT  # inv(M_row).T = inv(M_row.T)
+    # Transform to fractional coordinates: f = B·r
+    # For each atom, multiply its position by its batch's inverse cell matrix
+    frac_coords = torch.bmm(B_per_atom, positions.unsqueeze(2)).squeeze(2)
 
-    # Map inv(M_row.T) to each atom
-    inv_cell_T_per_atom = inv_cell_T[batch]  # Shape: (n_atoms, 3, 3)
-
-    # Transform to fractional coordinates: f_row = r_row @ inv(M_row.T)
-    frac_coords = torch.einsum("ni,nij->nj", positions, inv_cell_T_per_atom)
-
-    # Wrap fractional coordinates to [0, 1) using f - floor(f)
+    # Wrap to reference cell [0,1) using f - floor(f)
     wrapped_frac = frac_coords - torch.floor(frac_coords)
 
-    # Handle edge case for positions exactly on upper boundary
+    # Handle edge case of positions exactly on upper boundary
     wrapped_frac = torch.where(
         torch.isclose(wrapped_frac, torch.ones_like(wrapped_frac)),
         torch.zeros_like(wrapped_frac),
         wrapped_frac,
     )
 
-    # Transform back to real space: r_row' = f_row' @ M_row
-    # Map M_row to each atom
+    # Transform back to real space: r = A·f
+    # Get the cell for each atom based on its batch index
     cell_per_atom = cell[batch]  # Shape: (n_atoms, 3, 3)
 
-    # Transform back to real space: r'_i = f'_i @ M_row_i
-    return torch.einsum("ni,nij->nj", wrapped_frac, cell_per_atom)
+    # For each atom, multiply its wrapped fractional coords by its batch's cell matrix
+    return torch.bmm(cell_per_atom, wrapped_frac.unsqueeze(2)).squeeze(2)
 
 
 def minimum_image_displacement(
@@ -218,8 +209,7 @@ def minimum_image_displacement(
 
     Args:
         dr (torch.Tensor): Displacement vectors [N, 3] or [N, N, 3].
-        cell (Optional[torch.Tensor]): Tensor of shape (3, 3) containing
-            lattice vectors as column vectors.
+        cell (Optional[torch.Tensor]): Unit cell matrix [3, 3].
         pbc (bool): Whether to apply periodic boundary conditions.
 
     Returns:
@@ -356,8 +346,7 @@ def wrap_positions(
 
     Args:
         positions (torch.Tensor): Atomic positions [N, 3].
-        cell (torch.Tensor): Tensor of shape (3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): Unit cell matrix [3, 3].
         pbc (Union[bool, list[bool], torch.Tensor]): Whether to apply
             periodic boundary conditions.
         center (Tuple[float, float, float]): Center of the cell as
@@ -441,14 +430,14 @@ def get_number_of_cell_repeats(
 
     Args:
         cutoff (float): The cutoff distance for interactions.
-        cell (torch.Tensor): Tensor of shape (n_batches, 3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor of shape (n_cells, 3, 3)
+            representing the unit cell matrices.
         pbc (torch.Tensor): A tensor of shape (n_cells, 3)
             indicating whether periodic boundary conditions are
             applied in each dimension.
 
     Returns:
-        torch.Tensor: A tensor of shape (n_batches, 3)
+        torch.Tensor: A tensor of shape (n_cells, 3)
             containing the number of repeats for each dimension,
             where non-PBC dimensions are set to zero.
     """
@@ -539,8 +528,8 @@ def compute_cell_shifts(
     indices and the unit cell matrix. If the cell is None, it returns None.
 
     Args:
-        cell (torch.Tensor): Tensor of shape (n_batches, 3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor of shape (n_cells, 3, 3)
+            representing the unit cell matrices.
         shifts_idx (torch.Tensor): A tensor of shape (n_shifts, 3)
             representing the indices for shifts.
         batch_mapping (torch.Tensor): A tensor of shape (n_batches,)
@@ -626,8 +615,8 @@ def build_naive_neighborhood(
     Args:
         positions (torch.Tensor): A tensor of shape (n_atoms, 3)
             representing the positions of atoms.
-        cell (torch.Tensor): Tensor of shape (n_batches, 3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor of shape (n_cells, 3, 3)
+            representing the unit cell matrices.
         pbc (torch.Tensor): A tensor indicating whether
             periodic boundary conditions are applied.
         cutoff (float): The cutoff distance beyond which atoms are not
@@ -740,8 +729,8 @@ def get_linear_bin_idx(
     cell dimensions, and then the corresponding bin indices are determined.
 
     Args:
-        cell (torch.Tensor): Tensor of shape (3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor of shape [3, 3]
+            representing the cell vectors defining the box.
         pos (torch.Tensor): A tensor of shape [-1, 3]
             representing the set of positions to be binned.
         n_bins_s (torch.Tensor): A tensor of shape [3]
@@ -813,8 +802,8 @@ def linked_cell(  # noqa: PLR0915
     Args:
         pos (torch.Tensor): A tensor of shape [n_atom, 3] representing
             atomic positions in the unit cell.
-        cell (torch.Tensor): Tensor of shape (3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor of shape [3, 3] representing
+            the unit cell vectors.
         cutoff (float): The distance threshold used to determine which
             atoms are considered neighbors.
         num_repeats (torch.Tensor): A tensor indicating the number of
@@ -978,8 +967,8 @@ def build_linked_cell_neighborhood(
         positions (torch.Tensor): A tensor containing the atomic positions
             for each structure, where each row corresponds to an atom's position
             in 3D space.
-        cell (torch.Tensor): Tensor of shape (n_batches, 3, 3) containing
-            lattice vectors as column vectors.
+        cell (torch.Tensor): A tensor containing the unit cell vectors for
+            each structure, formatted as a 3D array.
         pbc (torch.Tensor): A boolean tensor indicating the periodic boundary
             conditions to apply for each structure.
         cutoff (float): The distance threshold used to determine which atoms are

--- a/torch_sim/unbatched/unbatched_integrators.py
+++ b/torch_sim/unbatched/unbatched_integrators.py
@@ -153,9 +153,7 @@ def position_step(state: MDState, dt: torch.Tensor) -> MDState:
     new_positions = state.positions + state.velocities * dt
 
     if state.pbc:
-        new_positions = pbc_wrap_general(
-            positions=new_positions, lattice_vectors=state.cell.T
-        )
+        new_positions = pbc_wrap_general(new_positions, state.cell)
 
     state.positions = new_positions
     return state
@@ -820,15 +818,13 @@ def npt_langevin(  # noqa: C901, PLR0915
         )
 
         # Update positions with all contributions
-        state.positions = c_1 + c_2 * c_3
+        new_positions = c_1 + c_2 * c_3
 
         # Apply periodic boundary conditions if needed
         if state.pbc:
-            new_positions = pbc_wrap_general(
-                positions=state.positions, lattice_vectors=state.cell.T
-            )
-            state.positions = new_positions
+            new_positions = pbc_wrap_general(state.positions, state.cell)
 
+        state.positions = new_positions
         return state
 
     def langevin_velocity_step(

--- a/torch_sim/unbatched/unbatched_integrators.py
+++ b/torch_sim/unbatched/unbatched_integrators.py
@@ -822,7 +822,7 @@ def npt_langevin(  # noqa: C901, PLR0915
 
         # Apply periodic boundary conditions if needed
         if state.pbc:
-            new_positions = pbc_wrap_general(state.positions, state.cell)
+            new_positions = pbc_wrap_general(new_positions, state.cell)
 
         state.positions = new_positions
         return state


### PR DESCRIPTION
## Summary

The tests of the function do not use the row vector cell so this suggests this is a bug that it's used in the integrators.

see that tests of function don't use the swap axis: https://github.com/Radical-AI/torch-sim/blob/d2cee6628ff3b4a8da7557772cc12a669a0c09b4/tests/test_transforms.py#L267

## Checklist
* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.
