### PR TITLE
Remove metatensor example from CI until dependency resolution issue has solution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,8 +135,8 @@ jobs:
       - name: Find example scripts
         id: set-matrix
         run: |
-          # Find all example scripts but exclude known failing ones
-          EXAMPLES=$(find examples -name "*.py" | jq -R -s -c 'split("\n")[:-1]')
+          # Find all example scripts but exclude the metatensor tutorial
+          EXAMPLES=$(find examples -name "*.py" -not -path "examples/tutorials/metatensor_tutorial.py" | jq -R -s -c 'split("\n")[:-1]')
           echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
 
   test-examples:

--- a/examples/tutorials/metatensor_tutorial.py
+++ b/examples/tutorials/metatensor_tutorial.py
@@ -17,6 +17,10 @@
 This tutorial explains how to use the PET-MAD model (https://arxiv.org/abs/2503.14118)
 via TorchSim's metatensor interface.
 
+NOTE: This tutorial is not currently run as part of CI due to an issue with how
+uv run resolves the dependencies and the recent release of pytorch 2.7. The following
+issue is relevant to tracking the dependency issues: https://github.com/astral-sh/uv/issues/13173
+
 ## Loading the model
 
 Loading the model is simple: you simply need to specify the model name (in this case


### PR DESCRIPTION
## Summary

Do not run the metatensor example in CI. This is temporary due to it not working with how we're handling dependencies via uv run for the examples in CI. 

See: https://github.com/astral-sh/uv/issues/13173, https://github.com/Radical-AI/torch-sim/issues/178

## Checklist
* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.
