### PR TITLE
use `"SimState"` type rather than `Self` in state.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ coverage.xml
 
 # env
 uv.lock
+
+.vscode/


### PR DESCRIPTION
## Summary

This fixes a few type errors I've been getting via pylance.

I've talked to Janosh about the larger typing issues in the codebase but I currently do not have time to look into those right now. So I want to merge this PR in so others don't think I'm fixing all of the other typing issues.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
