### PR TITLE
Top-level `SimState`

### DIFF
--- a/examples/scripts/1_Introduction/1.2_MACE.py
+++ b/examples/scripts/1_Introduction/1.2_MACE.py
@@ -11,6 +11,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 
 
@@ -19,9 +20,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/1_Introduction/1.3_Batched_MACE.py
+++ b/examples/scripts/1_Introduction/1.3_Batched_MACE.py
@@ -11,7 +11,7 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 # Set device and data type
@@ -19,9 +19,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.10_Batched_MACE_FrechetCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.10_Batched_MACE_FrechetCellFilter_FIRE.py
@@ -14,7 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.units import UnitConversion
 
 
@@ -23,9 +23,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.2_Soft_Sphere_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.2_Soft_Sphere_FIRE.py
@@ -11,7 +11,7 @@ import os
 
 import torch
 
-from torch_sim.state import SimState
+import torch_sim as ts
 from torch_sim.unbatched.models.soft_sphere import UnbatchedSoftSphereModel
 from torch_sim.unbatched.unbatched_optimizers import fire
 
@@ -75,7 +75,7 @@ atomic_numbers = torch.full((positions.shape[0],), 29, device=device, dtype=torc
 # Cu atomic mass in atomic mass units
 masses = torch.full((positions.shape[0],), 63.546, device=device, dtype=dtype)
 
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/2_Structural_optimization/2.3_MACE_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.3_MACE_FIRE.py
@@ -13,7 +13,7 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
-from torch_sim.state import SimState
+import torch_sim as ts
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_optimizers import fire
 
@@ -58,7 +58,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=False,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/2_Structural_optimization/2.3_MACE_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.3_MACE_FIRE.py
@@ -14,6 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_optimizers import fire
 
@@ -23,9 +24,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.4_MACE_UnitCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.4_MACE_UnitCellFilter_FIRE.py
@@ -14,6 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_optimizers import unit_cell_fire
 from torch_sim.units import UnitConversion
@@ -24,9 +25,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.5_MACE_FrechetCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.5_MACE_FrechetCellFilter_FIRE.py
@@ -14,6 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_optimizers import frechet_cell_fire
 from torch_sim.units import UnitConversion
@@ -24,9 +25,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.6_Batched_MACE_Gradient_Descent.py
+++ b/examples/scripts/2_Structural_optimization/2.6_Batched_MACE_Gradient_Descent.py
@@ -14,7 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.optimizers import gradient_descent
 
 
@@ -23,9 +23,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.7_Batched_MACE_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.7_Batched_MACE_FIRE.py
@@ -14,7 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.optimizers import fire
 
 
@@ -23,9 +23,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-mp/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.8_Batched_MACE_UnitCellFilter_Gradient_Descent.py
+++ b/examples/scripts/2_Structural_optimization/2.8_Batched_MACE_UnitCellFilter_Gradient_Descent.py
@@ -14,7 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.optimizers import unit_cell_gradient_descent
 from torch_sim.units import UnitConversion
 
@@ -24,9 +24,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/2_Structural_optimization/2.9_Batched_MACE_UnitCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.9_Batched_MACE_UnitCellFilter_FIRE.py
@@ -14,7 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.optimizers import unit_cell_fire
 from torch_sim.units import UnitConversion
 
@@ -24,9 +24,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.10_Hybrid_swap_mc.py
+++ b/examples/scripts/3_Dynamics/3.10_Hybrid_swap_mc.py
@@ -15,7 +15,7 @@ from pymatgen.core import Structure
 
 import torch_sim as ts
 from torch_sim.integrators import MDState, nvt_langevin
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.monte_carlo import swap_monte_carlo
 from torch_sim.units import MetalUnits
 
@@ -26,9 +26,8 @@ dtype = torch.float64
 kT = 1000 * MetalUnits.temperature
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.11_Lennard_Jones_NPT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.11_Lennard_Jones_NPT_Langevin.py
@@ -11,8 +11,8 @@ import os
 
 import torch
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.lennard_jones import UnbatchedLennardJonesModel
 from torch_sim.unbatched.unbatched_integrators import npt_langevin
 from torch_sim.units import MetalUnits as Units
@@ -92,7 +92,7 @@ model = UnbatchedLennardJonesModel(
     compute_forces=True,
     compute_stress=True,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
@@ -13,6 +13,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
@@ -28,9 +29,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
@@ -12,8 +12,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     npt_langevin,
@@ -62,7 +62,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=False,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.13_MACE_NVE_non_pbc.py
+++ b/examples/scripts/3_Dynamics/3.13_MACE_NVE_non_pbc.py
@@ -14,6 +14,7 @@ from ase.build import molecule
 from mace.calculators.foundations_models import mace_off
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kinetic_energy
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nve
@@ -25,9 +26,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-off/raw/refs/heads/main/mace_off23/MACE-OFF23b_medium.model"
 loaded_model = mace_off(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.1_Lennard_Jones_NVE.py
+++ b/examples/scripts/3_Dynamics/3.1_Lennard_Jones_NVE.py
@@ -11,8 +11,8 @@ import os
 
 import torch
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.lennard_jones import UnbatchedLennardJonesModel
 from torch_sim.unbatched.unbatched_integrators import nve
 from torch_sim.units import MetalUnits as Units
@@ -76,7 +76,7 @@ atomic_numbers = torch.full((positions.shape[0],), 18, device=device, dtype=torc
 # Create the masses tensor (Argon = 39.948 amu)
 masses = torch.full((positions.shape[0],), 39.948, device=device, dtype=dtype)
 
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
+++ b/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
@@ -13,8 +13,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nve
 from torch_sim.units import MetalUnits as Units
@@ -59,7 +59,7 @@ model = UnbatchedMaceModel(
     enable_cueq=False,
 )
 
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
+++ b/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
@@ -14,6 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kinetic_energy
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nve
@@ -25,9 +26,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
+++ b/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
@@ -13,8 +13,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nve
 from torch_sim.units import MetalUnits as Units
@@ -58,7 +58,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=torch.cuda.is_available(),
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
+++ b/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
@@ -14,6 +14,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kinetic_energy
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nve
@@ -25,9 +26,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
@@ -13,6 +13,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nvt_langevin
@@ -24,9 +25,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
@@ -12,8 +12,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import nvt_langevin
 from torch_sim.units import MetalUnits as Units
@@ -58,7 +58,7 @@ model = UnbatchedMaceModel(
     enable_cueq=False,
 )
 
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
@@ -13,6 +13,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
@@ -27,9 +28,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
@@ -12,8 +12,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     nvt_nose_hoover,
@@ -60,7 +60,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=False,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
+++ b/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
@@ -19,6 +19,7 @@ from mace.calculators.foundations_models import mace_mp
 from plotly.subplots import make_subplots
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
@@ -81,9 +82,8 @@ dtype = torch.float32
 
 # Model configuration
 # Option 1: Load from URL (uncomment to use)
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
+++ b/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
@@ -18,8 +18,8 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 from plotly.subplots import make_subplots
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     nvt_nose_hoover,
@@ -141,7 +141,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=False,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.7_Lennard_Jones_NPT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.7_Lennard_Jones_NPT_Nose_Hoover.py
@@ -11,8 +11,8 @@ import os
 
 import torch
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.lennard_jones import UnbatchedLennardJonesModel
 from torch_sim.unbatched.unbatched_integrators import (
     npt_nose_hoover,
@@ -94,7 +94,7 @@ model = UnbatchedLennardJonesModel(
     compute_forces=True,
     compute_stress=True,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
@@ -12,8 +12,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     npt_nose_hoover,
@@ -63,7 +63,7 @@ model = UnbatchedMaceModel(
     dtype=dtype,
     enable_cueq=False,
 )
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
@@ -13,6 +13,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
@@ -29,9 +30,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
+++ b/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
@@ -12,8 +12,8 @@ import torch
 from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     nvt_nose_hoover,
@@ -61,7 +61,7 @@ model = UnbatchedMaceModel(
     enable_cueq=False,
 )
 
-state = SimState(
+state = ts.SimState(
     positions=positions,
     masses=masses,
     cell=cell,

--- a/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
+++ b/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
@@ -13,6 +13,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.quantities import calc_kT
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
@@ -27,9 +28,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/4_High_level_api/4.1_high_level_api.py
+++ b/examples/scripts/4_High_level_api/4.1_high_level_api.py
@@ -23,7 +23,6 @@ from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.models.mace import MaceModel
 from torch_sim.optimizers import unit_cell_fire
 from torch_sim.quantities import calc_kinetic_energy
-from torch_sim.runners import integrate, optimize
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 from torch_sim.units import MetalUnits
 
@@ -37,7 +36,7 @@ lj_model = LennardJonesModel(
 
 si_atoms = bulk("Si", "fcc", a=5.43, cubic=True)
 
-final_state = integrate(
+final_state = ts.integrate(
     system=si_atoms,
     model=lj_model,
     integrator=nvt_langevin,
@@ -64,7 +63,7 @@ reporter = TrajectoryReporter(
     prop_calculators=prop_calculators,
 )
 
-final_state = integrate(
+final_state = ts.integrate(
     system=si_atoms,
     model=lj_model,
     integrator=nvt_langevin,
@@ -104,7 +103,7 @@ reporter = TrajectoryReporter(
     prop_calculators=prop_calculators,
 )
 
-final_state = integrate(
+final_state = ts.integrate(
     system=si_atoms,
     model=mace_model,
     integrator=nvt_langevin,
@@ -122,7 +121,7 @@ fe_atoms = bulk("Fe", "fcc", a=5.26, cubic=True)
 fe_atoms_supercell = fe_atoms.repeat([2, 2, 2])
 si_atoms_supercell = si_atoms.repeat([2, 2, 2])
 
-final_state = integrate(
+final_state = ts.integrate(
     system=[si_atoms, fe_atoms, si_atoms_supercell, fe_atoms_supercell],
     model=mace_model,
     integrator=nvt_langevin,
@@ -144,7 +143,7 @@ batch_reporter = TrajectoryReporter(
     state_frequency=100,
     prop_calculators=prop_calculators,
 )
-final_state = integrate(
+final_state = ts.integrate(
     system=systems,
     model=mace_model,
     integrator=nvt_langevin,
@@ -163,7 +162,7 @@ for filename in filenames:
 
 systems = [si_atoms, fe_atoms, si_atoms_supercell, fe_atoms_supercell]
 
-final_state = optimize(
+final_state = ts.optimize(
     system=systems,
     model=mace_model,
     optimizer=unit_cell_fire,
@@ -177,7 +176,7 @@ rng = np.random.default_rng()
 for system in systems:
     system.positions += rng.random(system.positions.shape) * 0.01
 
-final_state = optimize(
+final_state = ts.optimize(
     system=systems,
     model=mace_model,
     optimizer=unit_cell_fire,
@@ -200,7 +199,7 @@ coords = [
     [0.75, 0.75, 0.25],
 ]
 structure = Structure(lattice, species, coords)
-final_state = integrate(
+final_state = ts.integrate(
     system=structure,
     model=lj_model,
     integrator=nvt_langevin,

--- a/examples/scripts/5_Workflow/5.1_a2c_silicon.py
+++ b/examples/scripts/5_Workflow/5.1_a2c_silicon.py
@@ -24,6 +24,7 @@ from pymatgen.core import Composition, Element, Structure
 from tqdm import tqdm
 
 import torch_sim as ts
+from torch_sim.models.mace import MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     NVTNoseHooverState,
@@ -55,8 +56,7 @@ structure_multi = random_packed_structure_multi(
 device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
-raw_model = mace_mp(model=mace_checkpoint_url, return_raw_model=True)
+raw_model = mace_mp(model=MaceUrls.mace_mpa_medium, return_raw_model=True)
 
 # Define system and model
 comp = Composition("Si64")

--- a/examples/scripts/5_Workflow/5.2_a2c_silicon_batched.py
+++ b/examples/scripts/5_Workflow/5.2_a2c_silicon_batched.py
@@ -24,7 +24,7 @@ from pymatgen.core import Composition, Element, Structure
 from tqdm import tqdm
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.unbatched.models.mace import UnbatchedMaceModel
 from torch_sim.unbatched.unbatched_integrators import (
     NVTNoseHooverState,
@@ -56,8 +56,7 @@ structure_multi = random_packed_structure_multi(
 device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
-raw_model = mace_mp(model=mace_checkpoint_url, return_raw_model=True)
+raw_model = mace_mp(model=MaceUrls.mace_mpa_medium, return_raw_model=True)
 
 # Define system and model
 comp = Composition("Si64")

--- a/examples/scripts/5_Workflow/5.3_In_Flight_WBM.py
+++ b/examples/scripts/5_Workflow/5.3_In_Flight_WBM.py
@@ -15,7 +15,7 @@ import torch
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 # --- Setup and Configuration ---
@@ -26,8 +26,7 @@ print(f"job will run on {device=}")
 
 # --- Model Initialization ---
 print("Loading MACE model...")
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
-mace = mace_mp(model=mace_checkpoint_url, return_raw_model=True)
+mace = mace_mp(model=MaceUrls.mace_mpa_medium, return_raw_model=True)
 mace_model = MaceModel(
     model=mace,
     device=device,

--- a/examples/scripts/5_Workflow/5.4_Elastic.py
+++ b/examples/scripts/5_Workflow/5.4_Elastic.py
@@ -13,16 +13,15 @@ from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
 from torch_sim.elastic import get_bravais_type
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 # Calculator
 unit_conv = ts.units.UnitConversion
 device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float64
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     enable_cueq=False,
     device=device,
     default_dtype="float64",

--- a/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
+++ b/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
@@ -24,7 +24,7 @@ from phonopy.phonon.band_structure import (
 )
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 def get_qpts_and_connections(
@@ -90,9 +90,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float32
 
 # Load the raw model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
+++ b/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
@@ -23,7 +23,7 @@ from phonopy.api_qha import PhonopyQHA
 from phonopy.structure.atoms import PhonopyAtoms
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 def get_relaxed_structure(
@@ -213,9 +213,8 @@ dtype = torch.float64
 autobatcher = False
 
 # Load the raw model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/scripts/6_Phonons/6.3_Conductivity_MACE.py
+++ b/examples/scripts/6_Phonons/6.3_Conductivity_MACE.py
@@ -22,7 +22,7 @@ from mace.calculators.foundations_models import mace_mp
 from phono3py import Phono3py
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 
 def print_relax_info(trajectory_file: str, device: torch.device) -> None:
@@ -51,9 +51,11 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 dtype = torch.float64
 
 # Load the raw model from URL
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url, return_raw_model=True, default_dtype=dtype, device=device
+    model=MaceUrls.mace_mpa_medium,
+    return_raw_model=True,
+    default_dtype=dtype,
+    device=device,
 )
 model = MaceModel(
     model=loaded_model,

--- a/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
+++ b/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
@@ -17,7 +17,7 @@ from ase.build import bulk
 from mace.calculators.foundations_models import mace_mp
 
 import torch_sim as ts
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.optimizers import fire
 from torch_sim.state import SimState
 
@@ -28,9 +28,8 @@ dtype = torch.float32
 unit_conv = ts.units.UnitConversion
 
 # Option 1: Load the raw model from the downloaded model
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/examples/tutorials/low_level_tutorial.py
+++ b/examples/tutorials/low_level_tutorial.py
@@ -65,12 +65,11 @@ Then we can initialize the MaceModel class with the raw model.
 
 # %%
 from mace.calculators.foundations_models import mace_mp
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 
 # load mace_mp using the mace package
-mace_checkpoint_url = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
 loaded_model = mace_mp(
-    model=mace_checkpoint_url,
+    model=MaceUrls.mace_mpa_medium,
     return_raw_model=True,
     default_dtype=dtype,
     device=device,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -11,18 +10,13 @@ from pymatgen.core import Structure
 
 import torch_sim as ts
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.models.mace import MaceModel
+from torch_sim.models.mace import MaceModel, MaceUrls
 from torch_sim.state import concatenate_states
 from torch_sim.unbatched.models.lennard_jones import UnbatchedLennardJonesModel
 
 
 if TYPE_CHECKING:
     from mace.calculators import MACECalculator
-
-
-class MaceUrls(StrEnum):
-    mace_small = "https://github.com/ACEsuit/mace-mp/releases/download/mace_mp_0b/mace_agnesi_small.model"
-    mace_off_small = "https://github.com/ACEsuit/mace-off/blob/main/mace_off23/MACE-OFF23_small.model?raw=true"
 
 
 @pytest.fixture
@@ -336,7 +330,7 @@ def ase_mace_mpa() -> "MACECalculator":
     from mace.calculators.foundations_models import mace_mp
 
     # Ensure dtype matches the one used in the torchsim fixture (float64)
-    return mace_mp(model=MaceUrls.mace_small, default_dtype="float64")
+    return mace_mp(model=MaceUrls.mace_mp_small, default_dtype="float64")
 
 
 @pytest.fixture
@@ -347,7 +341,7 @@ def torchsim_mace_mpa() -> MaceModel:
     # Use float64 for potentially higher precision needed in optimization
     dtype = getattr(torch, dtype_str := "float64")
     raw_mace = mace_mp(
-        model=MaceUrls.mace_small, return_raw_model=True, default_dtype=dtype_str
+        model=MaceUrls.mace_mp_small, return_raw_model=True, default_dtype=dtype_str
     )
     return MaceModel(
         model=raw_mace,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from pymatgen.core import Structure
 import torch_sim as ts
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.models.mace import MaceModel
-from torch_sim.state import SimState, concatenate_states
+from torch_sim.state import concatenate_states
 from torch_sim.unbatched.models.lennard_jones import UnbatchedLennardJonesModel
 
 
@@ -107,35 +107,35 @@ def si_sim_state(si_atoms: Any, device: torch.device, dtype: torch.dtype) -> Any
 
 
 @pytest.fixture
-def cu_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def cu_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline copper using ASE."""
     atoms = bulk("Cu", "fcc", a=3.58, cubic=True)
     return ts.io.atoms_to_state(atoms, device, dtype)
 
 
 @pytest.fixture
-def mg_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def mg_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline magnesium using ASE."""
     atoms = bulk("Mg", "hcp", a=3.17, c=5.14)
     return ts.io.atoms_to_state(atoms, device, dtype)
 
 
 @pytest.fixture
-def sb_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def sb_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline antimony using ASE."""
     atoms = bulk("Sb", "rhombohedral", a=4.58, alpha=60)
     return ts.io.atoms_to_state(atoms, device, dtype)
 
 
 @pytest.fixture
-def ti_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def ti_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline titanium using ASE."""
     atoms = bulk("Ti", "hcp", a=2.94, c=4.64)
     return ts.io.atoms_to_state(atoms, device, dtype)
 
 
 @pytest.fixture
-def tio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def tio2_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline TiO2 using ASE."""
     a, c = 4.60, 2.96
     basis = [("Ti", 0.5, 0.5, 0), ("O", 0.695679, 0.695679, 0.5)]
@@ -149,7 +149,7 @@ def tio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 
 
 @pytest.fixture
-def ga_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def ga_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline Ga using ASE."""
     a, b, c = 4.43, 7.60, 4.56
     basis = [("Ga", 0, 0.344304, 0.415401)]
@@ -163,7 +163,7 @@ def ga_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 
 
 @pytest.fixture
-def niti_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def niti_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create crystalline NiTi using ASE."""
     a, b, c = 2.89, 3.97, 4.83
     alpha, beta, gamma = 90.00, 105.23, 90.00
@@ -181,7 +181,7 @@ def niti_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 
 
 @pytest.fixture
-def sio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def sio2_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     """Create an alpha-quartz SiO2 system for testing."""
     atoms = crystal(
         symbols=["O", "Si"],
@@ -194,10 +194,10 @@ def sio2_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
 
 @pytest.fixture
 def rattled_sio2_sim_state(
-    sio2_sim_state: SimState,
+    sio2_sim_state: ts.SimState,
     device: torch.device,
     dtype: torch.dtype,
-) -> SimState:
+) -> ts.SimState:
     """Create a rattled SiO2 system for testing."""
     sim_state = sio2_sim_state.clone()
 
@@ -219,7 +219,7 @@ def rattled_sio2_sim_state(
 
 
 @pytest.fixture
-def casio3_sim_state(device: torch.device, dtype: torch.dtype) -> SimState:
+def casio3_sim_state(device: torch.device, dtype: torch.dtype) -> ts.SimState:
     a, b, c = 7.9258, 7.3202, 7.0653
     alpha, beta, gamma = 90.055, 95.217, 103.426
     basis = [
@@ -267,13 +267,13 @@ def fe_supercell_sim_state(
 @pytest.fixture
 def ar_supercell_sim_state(
     ar_atoms: Atoms, device: torch.device, dtype: torch.dtype
-) -> SimState:
+) -> ts.SimState:
     """Create a face-centered cubic (FCC) Argon structure with 2x2x2 supercell."""
     return ts.io.atoms_to_state(ar_atoms.repeat([2, 2, 2]), device, dtype)
 
 
 @pytest.fixture
-def ar_double_sim_state(ar_supercell_sim_state: SimState) -> SimState:
+def ar_double_sim_state(ar_supercell_sim_state: ts.SimState) -> ts.SimState:
     """Create a batched state from ar_fcc_sim_state."""
     return concatenate_states(
         [ar_supercell_sim_state, ar_supercell_sim_state],
@@ -289,8 +289,8 @@ def si_double_sim_state(si_atoms: Atoms, device: torch.device, dtype: torch.dtyp
 
 @pytest.fixture
 def mixed_double_sim_state(
-    ar_supercell_sim_state: SimState, si_sim_state: SimState
-) -> SimState:
+    ar_supercell_sim_state: ts.SimState, si_sim_state: ts.SimState
+) -> ts.SimState:
     """Create a batched state from ar_fcc_sim_state."""
     return concatenate_states(
         [ar_supercell_sim_state, si_sim_state],

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -11,7 +11,6 @@ if typing.TYPE_CHECKING:
     from ase.calculators.calculator import Calculator
 
     from torch_sim.models.interface import ModelInterface
-    from torch_sim.state import SimState
 
 
 consistency_test_simstate_fixtures: Final[tuple[str, ...]] = (
@@ -64,7 +63,7 @@ def make_model_calculator_consistency_test(
         calculator: Calculator = request.getfixturevalue(calculator_fixture_name)
 
         # Get the sim_state fixture dynamically using the name
-        sim_state: SimState = request.getfixturevalue(sim_state_name).to(device, dtype)
+        sim_state: ts.SimState = request.getfixturevalue(sim_state_name).to(device, dtype)
 
         # Set up ASE calculator
         atoms = ts.io.state_to_atoms(sim_state)[0]

--- a/tests/models/test_lennard_jones.py
+++ b/tests/models/test_lennard_jones.py
@@ -6,7 +6,6 @@ from ase.build import bulk
 
 import torch_sim as ts
 from torch_sim.models.interface import validate_model_outputs
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.lennard_jones import (
     UnbatchedLennardJonesModel,
     lennard_jones_pair,
@@ -137,7 +136,7 @@ def test_lennard_jones_force_energy_consistency() -> None:
 #       is not used in the neighbor list calculation. So to get correct results,
 #       we need a system that is large enough (2*cutoff).
 @pytest.fixture
-def ar_supercell_sim_state_large(device: torch.device) -> SimState:
+def ar_supercell_sim_state_large(device: torch.device) -> ts.SimState:
     """Create a face-centered cubic (FCC) Argon structure."""
     # Create FCC Ar using ASE, with 4x4x4 supercell
     ar_atoms = bulk("Ar", "fcc", a=5.26, cubic=True).repeat([4, 4, 4])
@@ -146,7 +145,7 @@ def ar_supercell_sim_state_large(device: torch.device) -> SimState:
 
 @pytest.fixture
 def models(
-    ar_supercell_sim_state_large: SimState,
+    ar_supercell_sim_state_large: ts.SimState,
 ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
     """Create both neighbor list and direct models with Argon parameters."""
     calc_params = {

--- a/tests/models/test_mace.py
+++ b/tests/models/test_mace.py
@@ -140,3 +140,10 @@ def test_mace_off_dtype_working(
     state = ts.io.atoms_to_state([benzene_atoms], device, dtype)
 
     model.forward(state)
+
+
+def test_mace_urls_enum() -> None:
+    assert len(MaceUrls) > 2
+    for key in MaceUrls:
+        assert key.value.startswith("https://github.com/ACEsuit/mace-")
+        assert key.value.endswith((".model", ".model?raw=true"))

--- a/tests/models/test_mace.py
+++ b/tests/models/test_mace.py
@@ -3,12 +3,12 @@ import torch
 from ase.atoms import Atoms
 
 import torch_sim as ts
-from tests.conftest import MaceUrls
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
     make_validate_model_outputs_test,
 )
+from torch_sim.models.mace import MaceUrls
 
 
 try:
@@ -20,7 +20,7 @@ except (ImportError, ValueError):
     pytest.skip("MACE not installed", allow_module_level=True)
 
 
-mace_model = mace_mp(model=MaceUrls.mace_small, return_raw_model=True)
+mace_model = mace_mp(model=MaceUrls.mace_mp_small, return_raw_model=True)
 mace_off_model = mace_off(model=MaceUrls.mace_off_small, return_raw_model=True)
 
 
@@ -33,7 +33,7 @@ def dtype() -> torch.dtype:
 @pytest.fixture
 def ase_mace_calculator() -> MACECalculator:
     return mace_mp(
-        model=MaceUrls.mace_small,
+        model=MaceUrls.mace_mp_small,
         device="cpu",
         default_dtype="float32",
         dispersion=False,

--- a/tests/models/test_soft_sphere.py
+++ b/tests/models/test_soft_sphere.py
@@ -198,10 +198,7 @@ def test_model_initialization_custom_params(
     param_name: str, param_value: float, expected_dtype: torch.dtype
 ) -> None:
     """Test initialization with custom parameters."""
-    params = {
-        param_name: param_value,
-        "dtype": expected_dtype,
-    }
+    params = {param_name: param_value, "dtype": expected_dtype}
     model = ss.SoftSphereModel(**params)
 
     param_tensor = getattr(model, param_name)

--- a/tests/models/test_soft_sphere.py
+++ b/tests/models/test_soft_sphere.py
@@ -3,14 +3,14 @@
 import pytest
 import torch
 
+import torch_sim as ts
 import torch_sim.models.soft_sphere as ss
 from torch_sim.models.interface import validate_model_outputs
-from torch_sim.state import SimState, concatenate_states
 
 
 @pytest.fixture
 def models(
-    fe_supercell_sim_state: SimState,
+    fe_supercell_sim_state: ts.SimState,
 ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
     """Create both neighbor list and direct calculators."""
     calc_params = {
@@ -30,7 +30,7 @@ def models(
 
 @pytest.fixture
 def models_with_per_atom(
-    fe_supercell_sim_state: SimState,
+    fe_supercell_sim_state: ts.SimState,
 ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
     """Create calculators with per-atom properties enabled."""
     calc_params = {
@@ -62,10 +62,10 @@ def small_system() -> tuple[torch.Tensor, torch.Tensor]:
 
 
 @pytest.fixture
-def small_sim_state(small_system: tuple[torch.Tensor, torch.Tensor]) -> SimState:
+def small_sim_state(small_system: tuple[torch.Tensor, torch.Tensor]) -> ts.SimState:
     """Create a small SimState for testing."""
     positions, cell = small_system
-    return SimState(
+    return ts.SimState(
         positions=positions,
         cell=cell,
         pbc=torch.tensor([True, True, True]),
@@ -75,9 +75,9 @@ def small_sim_state(small_system: tuple[torch.Tensor, torch.Tensor]) -> SimState
 
 
 @pytest.fixture
-def small_batched_sim_state(small_sim_state: SimState) -> SimState:
+def small_batched_sim_state(small_sim_state: ts.SimState) -> ts.SimState:
     """Create a batched state from the small system."""
-    return concatenate_states(
+    return ts.concatenate_states(
         [small_sim_state, small_sim_state], device=small_sim_state.device
     )
 

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 import torch
 
+import torch_sim as ts
 from torch_sim.autobatching import (
     BinningAutoBatcher,
     InFlightAutoBatcher,
@@ -12,7 +13,6 @@ from torch_sim.autobatching import (
 )
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.optimizers import unit_cell_fire
-from torch_sim.state import SimState
 
 
 def test_exact_fit():
@@ -89,7 +89,7 @@ def test_bounds_and_tuples():
     ]
 
 
-def test_calculate_scaling_metric(si_sim_state: SimState) -> None:
+def test_calculate_scaling_metric(si_sim_state: ts.SimState) -> None:
     """Test calculation of scaling metrics for a state."""
     # Test n_atoms metric
     n_atoms_metric = calculate_memory_scaler(si_sim_state, "n_atoms")
@@ -106,7 +106,7 @@ def test_calculate_scaling_metric(si_sim_state: SimState) -> None:
         calculate_memory_scaler(si_sim_state, "invalid_metric")
 
 
-def test_split_state(si_double_sim_state: SimState) -> None:
+def test_split_state(si_double_sim_state: ts.SimState) -> None:
     """Test splitting a batched state into individual states."""
     split_states = si_double_sim_state.split()
 
@@ -125,7 +125,9 @@ def test_split_state(si_double_sim_state: SimState) -> None:
 
 
 def test_binning_auto_batcher(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test BinningAutoBatcher with different states."""
     # Create a list of states with different sizes
@@ -164,8 +166,8 @@ def test_binning_auto_batcher(
 
 
 def test_binning_auto_batcher_auto_metric(
-    si_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: LennardJonesModel,
     monkeypatch: Any,
 ) -> None:
@@ -211,7 +213,9 @@ def test_binning_auto_batcher_auto_metric(
 
 
 def test_binning_auto_batcher_with_indices(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test BinningAutoBatcher with return_indices=True."""
     states = [si_sim_state, fe_supercell_sim_state]
@@ -238,7 +242,9 @@ def test_binning_auto_batcher_with_indices(
 
 
 def test_binning_auto_batcher_restore_order_with_split_states(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test BinningAutoBatcher's restore_original_order method with split states."""
     # Create a list of states with different sizes
@@ -279,7 +285,9 @@ def test_binning_auto_batcher_restore_order_with_split_states(
 
 
 def test_in_flight_max_metric_too_small(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test InFlightAutoBatcher with different states."""
     # Create a list of states
@@ -297,7 +305,9 @@ def test_in_flight_max_metric_too_small(
 
 
 def test_in_flight_auto_batcher(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test InFlightAutoBatcher with different states."""
     # Create a list of states
@@ -314,16 +324,16 @@ def test_in_flight_auto_batcher(
 
     # Get the first batch
     first_batch, [], _ = batcher.next_batch(states, None)
-    assert isinstance(first_batch, SimState)
+    assert isinstance(first_batch, ts.SimState)
 
     # Create a convergence tensor where the first state has converged
     convergence = torch.tensor([True])
 
     # Get the next batch
     next_batch, popped_batch, idx = batcher.next_batch(first_batch, convergence)
-    assert isinstance(next_batch, SimState)
+    assert isinstance(next_batch, ts.SimState)
     assert isinstance(popped_batch, list)
-    assert isinstance(popped_batch[0], SimState)
+    assert isinstance(popped_batch[0], ts.SimState)
     assert idx == [1]
 
     # Check that the converged state was removed
@@ -343,7 +353,7 @@ def test_in_flight_auto_batcher(
 
 
 def test_determine_max_batch_size_fibonacci(
-    si_sim_state: SimState, lj_model: LennardJonesModel, monkeypatch: Any
+    si_sim_state: ts.SimState, lj_model: LennardJonesModel, monkeypatch: Any
 ) -> None:
     """Test that determine_max_batch_size uses Fibonacci sequence correctly."""
 
@@ -365,7 +375,9 @@ def test_determine_max_batch_size_fibonacci(
 
 
 def test_in_flight_auto_batcher_restore_order(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     """Test InFlightAutoBatcher's restore_original_order method."""
     states = [si_sim_state, fe_supercell_sim_state]
@@ -409,7 +421,9 @@ def test_in_flight_auto_batcher_restore_order(
 
 
 def test_in_flight_with_fire(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     fire_init, fire_update = unit_cell_fire(lj_model)
 
@@ -429,7 +443,7 @@ def test_in_flight_with_fire(
     )
     batcher.load_states(fire_states)
 
-    def convergence_fn(state: SimState) -> bool:
+    def convergence_fn(state: ts.SimState) -> bool:
         batch_wise_max_force = torch.zeros(
             state.n_batches, device=state.device, dtype=torch.float64
         )
@@ -459,7 +473,9 @@ def test_in_flight_with_fire(
 
 
 def test_binning_auto_batcher_with_fire(
-    si_sim_state: SimState, fe_supercell_sim_state: SimState, lj_model: LennardJonesModel
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
 ) -> None:
     fire_init, fire_update = unit_cell_fire(lj_model)
 
@@ -498,8 +514,8 @@ def test_binning_auto_batcher_with_fire(
 
 
 def test_in_flight_max_iterations(
-    si_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    si_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: LennardJonesModel,
 ) -> None:
     """Test InFlightAutoBatcher with max_iterations limit."""

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -1,13 +1,13 @@
 import pytest
 import torch
 
+import torch_sim as ts
 from torch_sim.elastic import (
     calculate_elastic_moduli,
     calculate_elastic_tensor,
     get_bravais_type,
 )
 from torch_sim.optimizers import frechet_cell_fire
-from torch_sim.state import SimState
 from torch_sim.typing import BravaisType
 from torch_sim.units import UnitConversion
 
@@ -109,7 +109,7 @@ def test_elastic_tensor_symmetries(
     )
 
 
-def test_copper_elastic_properties(mace_model: MaceModel, cu_sim_state: SimState):
+def test_copper_elastic_properties(mace_model: MaceModel, cu_sim_state: ts.SimState):
     """Test calculation of elastic properties for copper."""
 
     # Relax positions and cell

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 import torch
 
+import torch_sim as ts
 from torch_sim.integrators import (
     NPTLangevinState,
     calculate_momenta,
@@ -12,7 +13,7 @@ from torch_sim.integrators import (
 )
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.quantities import calc_kT
-from torch_sim.state import SimState, concatenate_states
+from torch_sim.state import concatenate_states
 from torch_sim.units import MetalUnits
 
 
@@ -86,7 +87,7 @@ def test_calculate_momenta_single_atoms(device: torch.device):
         )
 
 
-def test_npt_langevin(ar_double_sim_state: SimState, lj_model: LennardJonesModel):
+def test_npt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     dtype = torch.float64
     n_steps = 200
     dt = torch.tensor(0.001, dtype=dtype)
@@ -148,7 +149,7 @@ def test_npt_langevin(ar_double_sim_state: SimState, lj_model: LennardJonesModel
 
 
 def test_npt_langevin_multi_kt(
-    ar_double_sim_state: SimState, lj_model: LennardJonesModel
+    ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel
 ):
     dtype = torch.float64
     n_steps = 200
@@ -193,7 +194,7 @@ def test_npt_langevin_multi_kt(
     assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
 
 
-def test_nvt_langevin(ar_double_sim_state: SimState, lj_model: LennardJonesModel):
+def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
@@ -252,7 +253,7 @@ def test_nvt_langevin(ar_double_sim_state: SimState, lj_model: LennardJonesModel
 
 
 def test_nvt_langevin_multi_kt(
-    ar_double_sim_state: SimState, lj_model: LennardJonesModel
+    ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel
 ):
     dtype = torch.float64
     n_steps = 200
@@ -294,7 +295,7 @@ def test_nvt_langevin_multi_kt(
     assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
 
 
-def test_nve(ar_double_sim_state: SimState, lj_model: LennardJonesModel):
+def test_nve(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,7 +9,6 @@ from phonopy.structure.atoms import PhonopyAtoms
 from pymatgen.core import Structure
 
 import torch_sim as ts
-from torch_sim.state import SimState
 
 
 def test_single_structure_to_state(si_structure: Structure, device: torch.device) -> None:
@@ -17,7 +16,7 @@ def test_single_structure_to_state(si_structure: Structure, device: torch.device
     state = ts.io.structures_to_state(si_structure, device, torch.float64)
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert all(
         t.device.type == device.type for t in [state.positions, state.masses, state.cell]
     )
@@ -43,7 +42,7 @@ def test_multiple_structures_to_state(
     state = ts.io.structures_to_state([si_structure, si_structure], device, torch.float64)
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert state.positions.shape == (16, 3)
     assert state.masses.shape == (16,)
     assert state.cell.shape == (2, 3, 3)
@@ -60,7 +59,7 @@ def test_single_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
     state = ts.io.atoms_to_state(si_atoms, device, torch.float64)
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert state.positions.shape == (8, 3)
     assert state.masses.shape == (8,)
     assert state.cell.shape == (1, 3, 3)
@@ -75,7 +74,7 @@ def test_multiple_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
     state = ts.io.atoms_to_state([si_atoms, si_atoms], device, torch.float64)
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert state.positions.shape == (16, 3)
     assert state.masses.shape == (16,)
     assert state.cell.shape == (2, 3, 3)
@@ -87,7 +86,7 @@ def test_multiple_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
     )
 
 
-def test_state_to_structure(ar_supercell_sim_state: SimState) -> None:
+def test_state_to_structure(ar_supercell_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of pymatgen Structure."""
     structures = ts.io.state_to_structures(ar_supercell_sim_state)
     assert len(structures) == 1
@@ -95,7 +94,7 @@ def test_state_to_structure(ar_supercell_sim_state: SimState) -> None:
     assert len(structures[0]) == 32
 
 
-def test_state_to_multiple_structures(ar_double_sim_state: SimState) -> None:
+def test_state_to_multiple_structures(ar_double_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of pymatgen Structure."""
     structures = ts.io.state_to_structures(ar_double_sim_state)
     assert len(structures) == 2
@@ -105,7 +104,7 @@ def test_state_to_multiple_structures(ar_double_sim_state: SimState) -> None:
     assert len(structures[1]) == 32
 
 
-def test_state_to_atoms(ar_supercell_sim_state: SimState) -> None:
+def test_state_to_atoms(ar_supercell_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of ASE Atoms."""
     atoms = ts.io.state_to_atoms(ar_supercell_sim_state)
     assert len(atoms) == 1
@@ -113,7 +112,7 @@ def test_state_to_atoms(ar_supercell_sim_state: SimState) -> None:
     assert len(atoms[0]) == 32
 
 
-def test_state_to_multiple_atoms(ar_double_sim_state: SimState) -> None:
+def test_state_to_multiple_atoms(ar_double_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of ASE Atoms."""
     atoms = ts.io.state_to_atoms(ar_double_sim_state)
     assert len(atoms) == 2
@@ -123,13 +122,13 @@ def test_state_to_multiple_atoms(ar_double_sim_state: SimState) -> None:
     assert len(atoms[1]) == 32
 
 
-def test_to_atoms(ar_supercell_sim_state: SimState) -> None:
+def test_to_atoms(ar_supercell_sim_state: ts.SimState) -> None:
     """Test conversion from SimState to list of ASE Atoms."""
     atoms = ts.io.state_to_atoms(ar_supercell_sim_state)
     assert isinstance(atoms[0], Atoms)
 
 
-def test_to_structures(ar_supercell_sim_state: SimState) -> None:
+def test_to_structures(ar_supercell_sim_state: ts.SimState) -> None:
     """Test conversion from SimState to list of Pymatgen Structure."""
     structures = ts.io.state_to_structures(ar_supercell_sim_state)
     assert isinstance(structures[0], Structure)
@@ -140,7 +139,7 @@ def test_single_phonopy_to_state(si_phonopy_atoms: Any, device: torch.device) ->
     state = ts.io.phonopy_to_state(si_phonopy_atoms, device, torch.float64)
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert all(
         t.device.type == device.type for t in [state.positions, state.masses, state.cell]
     )
@@ -166,7 +165,7 @@ def test_multiple_phonopy_to_state(si_phonopy_atoms: Any, device: torch.device) 
     )
 
     # Check basic properties
-    assert isinstance(state, SimState)
+    assert isinstance(state, ts.SimState)
     assert state.positions.shape == (16, 3)
     assert state.masses.shape == (16,)
     assert state.cell.shape == (2, 3, 3)
@@ -178,7 +177,7 @@ def test_multiple_phonopy_to_state(si_phonopy_atoms: Any, device: torch.device) 
     )
 
 
-def test_state_to_phonopy(ar_supercell_sim_state: SimState) -> None:
+def test_state_to_phonopy(ar_supercell_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of PhonopyAtoms."""
     phonopy_atoms = ts.io.state_to_phonopy(ar_supercell_sim_state)
     assert len(phonopy_atoms) == 1
@@ -186,7 +185,7 @@ def test_state_to_phonopy(ar_supercell_sim_state: SimState) -> None:
     assert len(phonopy_atoms[0]) == 32
 
 
-def test_state_to_multiple_phonopy(ar_double_sim_state: SimState) -> None:
+def test_state_to_multiple_phonopy(ar_double_sim_state: ts.SimState) -> None:
     """Test conversion from state tensors to list of PhonopyAtoms."""
     phonopy_atoms = ts.io.state_to_phonopy(ar_double_sim_state)
     assert len(phonopy_atoms) == 2
@@ -234,7 +233,7 @@ def test_state_round_trip(
         dtype: Data type to use
     """
     # Get the sim_state fixture dynamically using the name
-    sim_state: SimState = request.getfixturevalue(sim_state_name)
+    sim_state: ts.SimState = request.getfixturevalue(sim_state_name)
     to_format_fn, from_format_fn = conversion_functions
     unique_batches = torch.unique(sim_state.batch)
 
@@ -243,7 +242,7 @@ def test_state_round_trip(
     assert len(intermediate_format) == len(unique_batches)
 
     # Convert back to state
-    round_trip_state: SimState = from_format_fn(intermediate_format, device, dtype)
+    round_trip_state: ts.SimState = from_format_fn(intermediate_format, device, dtype)
 
     # Check that all properties match
     assert torch.allclose(sim_state.positions, round_trip_state.positions)

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -10,7 +10,6 @@ from torch_sim.monte_carlo import (
     swaps_to_permutation,
     validate_permutation,
 )
-from torch_sim.state import SimState
 
 
 @pytest.fixture
@@ -38,21 +37,23 @@ def generator(device: torch.device) -> torch.Generator:
 
 
 @pytest.fixture
-def batched_diverse_state(diverse_structure: Structure, device: torch.device) -> SimState:
+def batched_diverse_state(
+    diverse_structure: Structure, device: torch.device
+) -> ts.SimState:
     return ts.io.structures_to_state(
         [diverse_structure] * 2, device=device, dtype=torch.float64
     )
 
 
 def test_generate_permutation(
-    batched_diverse_state: SimState, generator: torch.Generator
+    batched_diverse_state: ts.SimState, generator: torch.Generator
 ):
     swaps = generate_swaps(batched_diverse_state, generator=generator)
     permutation = swaps_to_permutation(swaps, batched_diverse_state.n_atoms)
     validate_permutation(permutation, batched_diverse_state.batch)
 
 
-def test_generate_swaps(batched_diverse_state: SimState, generator: torch.Generator):
+def test_generate_swaps(batched_diverse_state: ts.SimState, generator: torch.Generator):
     swaps = generate_swaps(batched_diverse_state, generator=generator)
 
     # Check shape and type
@@ -69,7 +70,7 @@ def test_generate_swaps(batched_diverse_state: SimState, generator: torch.Genera
 
 
 def test_swaps_to_permutation(
-    batched_diverse_state: SimState, generator: torch.Generator
+    batched_diverse_state: ts.SimState, generator: torch.Generator
 ):
     swaps = generate_swaps(batched_diverse_state, generator=generator)
     n_atoms = batched_diverse_state.n_atoms
@@ -90,7 +91,7 @@ def test_swaps_to_permutation(
         assert permutation[j] == i
 
 
-def test_validate_permutation(batched_diverse_state: SimState):
+def test_validate_permutation(batched_diverse_state: ts.SimState):
     # Valid permutation
     swaps = generate_swaps(batched_diverse_state)
     permutation = swaps_to_permutation(swaps, batched_diverse_state.n_atoms)
@@ -108,7 +109,7 @@ def test_validate_permutation(batched_diverse_state: SimState):
 
 
 def test_monte_carlo(
-    batched_diverse_state: SimState,
+    batched_diverse_state: ts.SimState,
     lj_model: torch.nn.Module,
 ):
     """Test the monte_carlo function that returns a step function and initial state."""

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -10,12 +10,11 @@ from torch_sim.integrators import nve, nvt_langevin
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.optimizers import unit_cell_fire
 from torch_sim.quantities import calc_kinetic_energy
-from torch_sim.state import SimState
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 
 
 def test_integrate_nve(
-    ar_supercell_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_supercell_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test NVE integration with LJ potential."""
     traj_file = tmp_path / "nve.h5md"
@@ -37,7 +36,7 @@ def test_integrate_nve(
         trajectory_reporter=reporter,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     assert traj_file.is_file()
 
     # Check energy conservation
@@ -48,7 +47,7 @@ def test_integrate_nve(
 
 
 def test_integrate_single_nvt(
-    ar_supercell_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_supercell_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test NVT integration with LJ potential."""
     traj_file = tmp_path / "nvt.h5md"
@@ -71,7 +70,7 @@ def test_integrate_single_nvt(
         gamma=0.1,  # ps^-1
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     assert traj_file.is_file()
 
     # Check energy fluctuations
@@ -81,7 +80,7 @@ def test_integrate_single_nvt(
         assert std_energy / np.mean(energies) < 0.2  # 20% tolerance for NVT
 
 
-def test_integrate_double_nvt(ar_double_sim_state: SimState, lj_model: Any) -> None:
+def test_integrate_double_nvt(ar_double_sim_state: ts.SimState, lj_model: Any) -> None:
     """Test NVT integration with LJ potential."""
     final_state = ts.integrate(
         system=ar_double_sim_state,
@@ -92,13 +91,13 @@ def test_integrate_double_nvt(ar_double_sim_state: SimState, lj_model: Any) -> N
         timestep=0.001,  # ps
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     assert final_state.n_atoms == 64
     assert not torch.isnan(final_state.energy).any()
 
 
 def test_integrate_double_nvt_with_reporter(
-    ar_double_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_double_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test NVT integration with LJ potential."""
     trajectory_files = [tmp_path / "nvt_0.h5md", tmp_path / "nvt_1.h5md"]
@@ -121,7 +120,7 @@ def test_integrate_double_nvt_with_reporter(
         gamma=0.1,  # ps^-1
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     assert final_state.n_atoms == 64
     assert all(traj_file.is_file() for traj_file in trajectory_files)
 
@@ -135,8 +134,8 @@ def test_integrate_double_nvt_with_reporter(
 
 
 def test_integrate_many_nvt(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
     tmp_path: Path,
 ) -> None:
@@ -167,7 +166,7 @@ def test_integrate_many_nvt(
         trajectory_reporter=reporter,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     assert all(traj_file.is_file() for traj_file in trajectory_files)
     assert not torch.isnan(final_state.energy).any()
     assert not torch.isnan(final_state.positions).any()
@@ -178,8 +177,8 @@ def test_integrate_many_nvt(
 
 
 def test_integrate_with_autobatcher(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
 ) -> None:
     """Test integration with autobatcher."""
@@ -204,7 +203,7 @@ def test_integrate_with_autobatcher(
         autobatcher=autobatcher,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
     for init_state, final_state in zip(states, split_final_state, strict=False):
         assert torch.all(final_state.atomic_numbers == init_state.atomic_numbers)
@@ -212,8 +211,8 @@ def test_integrate_with_autobatcher(
 
 
 def test_integrate_with_autobatcher_and_reporting(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
     tmp_path: Path,
 ) -> None:
@@ -259,7 +258,7 @@ def test_integrate_with_autobatcher_and_reporting(
 
     assert all(traj_file.is_file() for traj_file in trajectory_files)
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
     for init_state, final_state in zip(states, split_final_state, strict=False):
         assert torch.all(final_state.atomic_numbers == init_state.atomic_numbers)
@@ -280,7 +279,7 @@ def test_integrate_with_autobatcher_and_reporting(
 
 
 def test_optimize_fire(
-    ar_supercell_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_supercell_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test FIRE optimization with LJ potential."""
     trajectory_files = [tmp_path / "opt.h5md"]
@@ -313,7 +312,7 @@ def test_optimize_fire(
 
 
 def test_default_converged_fn(
-    ar_supercell_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_supercell_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test default converged function."""
     ar_supercell_sim_state.positions += (
@@ -343,7 +342,7 @@ def test_default_converged_fn(
 
 
 def test_batched_optimize_fire(
-    ar_double_sim_state: SimState,
+    ar_double_sim_state: ts.SimState,
     lj_model: Any,
     tmp_path: Path,
 ) -> None:
@@ -371,8 +370,8 @@ def test_batched_optimize_fire(
 
 
 def test_optimize_with_autobatcher(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
 ) -> None:
     """Test optimize with autobatcher."""
@@ -395,7 +394,7 @@ def test_optimize_with_autobatcher(
         autobatcher=autobatcher,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
     for init_state, final_state in zip(states, split_final_state, strict=False):
         assert torch.all(final_state.atomic_numbers == init_state.atomic_numbers)
@@ -403,8 +402,8 @@ def test_optimize_with_autobatcher(
 
 
 def test_optimize_with_autobatcher_and_reporting(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
     tmp_path: Path,
 ) -> None:
@@ -443,7 +442,7 @@ def test_optimize_with_autobatcher_and_reporting(
 
     assert all(traj_file.is_file() for traj_file in trajectory_files)
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
     for init_state, final_state in zip(states, split_final_state, strict=False):
         assert torch.all(final_state.atomic_numbers == init_state.atomic_numbers)
@@ -467,8 +466,8 @@ def test_optimize_with_autobatcher_and_reporting(
 
 
 def test_integrate_with_default_autobatcher(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: LennardJonesModel,
     monkeypatch: Any,
 ) -> None:
@@ -498,7 +497,7 @@ def test_integrate_with_default_autobatcher(
         autobatcher=True,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
 
     for init_state, final_state in zip(states, split_final_state, strict=False):
@@ -507,8 +506,8 @@ def test_integrate_with_default_autobatcher(
 
 
 def test_optimize_with_default_autobatcher(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: LennardJonesModel,
     monkeypatch: Any,
 ) -> None:
@@ -534,7 +533,7 @@ def test_optimize_with_default_autobatcher(
         autobatcher=True,
     )
 
-    assert isinstance(final_state, SimState)
+    assert isinstance(final_state, ts.SimState)
     split_final_state = final_state.split()
     for init_state, final_state in zip(states, split_final_state, strict=False):
         assert torch.all(final_state.atomic_numbers == init_state.atomic_numbers)
@@ -542,7 +541,7 @@ def test_optimize_with_default_autobatcher(
 
 
 def test_static_single(
-    ar_supercell_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_supercell_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test static calculation with LJ potential."""
     traj_file = tmp_path / "static.h5md"
@@ -581,7 +580,7 @@ def test_static_single(
 
 
 def test_static_double(
-    ar_double_sim_state: SimState, lj_model: Any, tmp_path: Path
+    ar_double_sim_state: ts.SimState, lj_model: Any, tmp_path: Path
 ) -> None:
     """Test static calculation with multiple systems."""
     trajectory_files = [tmp_path / "static_0.h5md", tmp_path / "static_1.h5md"]
@@ -613,8 +612,8 @@ def test_static_double(
 
 
 def test_static_with_autobatcher(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
 ) -> None:
     """Test static calculation with autobatcher."""
@@ -646,8 +645,8 @@ def test_static_with_autobatcher(
 
 
 def test_static_with_autobatcher_and_reporting(
-    ar_supercell_sim_state: SimState,
-    fe_supercell_sim_state: SimState,
+    ar_supercell_sim_state: ts.SimState,
+    fe_supercell_sim_state: ts.SimState,
     lj_model: Any,
     tmp_path: Path,
 ) -> None:
@@ -700,7 +699,7 @@ def test_static_with_autobatcher_and_reporting(
     )
 
 
-def test_static_no_filenames(ar_supercell_sim_state: SimState, lj_model: Any) -> None:
+def test_static_no_filenames(ar_supercell_sim_state: ts.SimState, lj_model: Any) -> None:
     """Test static calculation with no trajectory filenames."""
     reporter = TrajectoryReporter(
         filenames=None,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -7,9 +7,9 @@ import numpy as np
 import pytest
 import torch
 
+import torch_sim as ts
 from torch_sim.integrators import MDState
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.state import SimState
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 
 
@@ -531,7 +531,7 @@ def prop_calculators() -> dict[int, dict[str, Callable]]:
     }
 
 
-def test_report_no_properties(si_sim_state: SimState, tmp_path: Path) -> None:
+def test_report_no_properties(si_sim_state: ts.SimState, tmp_path: Path) -> None:
     """Test TrajectoryReporter with no properties."""
     reporter = TrajectoryReporter(
         tmp_path / "no_properties.hdf5",
@@ -556,7 +556,7 @@ def test_report_no_properties(si_sim_state: SimState, tmp_path: Path) -> None:
     assert "atomic_numbers" in trajectory.array_registry
 
 
-def test_report_no_filenames(si_sim_state: SimState, prop_calculators: dict) -> None:
+def test_report_no_filenames(si_sim_state: ts.SimState, prop_calculators: dict) -> None:
     """Test TrajectoryReporter with no filenames."""
     from torch_sim.state import initialize_state
 
@@ -586,7 +586,7 @@ def test_report_no_filenames(si_sim_state: SimState, prop_calculators: dict) -> 
 
 
 def test_single_batch_reporter(
-    si_sim_state: SimState, tmp_path: Path, prop_calculators: dict
+    si_sim_state: ts.SimState, tmp_path: Path, prop_calculators: dict
 ) -> None:
     """Test TrajectoryReporter with a single batch."""
     # Create a reporter with a single file
@@ -623,7 +623,7 @@ def test_single_batch_reporter(
 
 
 def test_multi_batch_reporter_filenames_none(
-    si_double_sim_state: SimState, prop_calculators: dict
+    si_double_sim_state: ts.SimState, prop_calculators: dict
 ) -> None:
     """Test TrajectoryReporter with multiple batches and no filenames."""
     reporter = TrajectoryReporter(
@@ -648,7 +648,7 @@ def test_multi_batch_reporter_filenames_none(
 
 
 def test_multi_batch_reporter(
-    si_double_sim_state: SimState, tmp_path: Path, prop_calculators: dict
+    si_double_sim_state: ts.SimState, tmp_path: Path, prop_calculators: dict
 ) -> None:
     """Test TrajectoryReporter with multiple batches."""
     # Create a reporter with multiple files
@@ -693,7 +693,7 @@ def test_multi_batch_reporter(
 
 
 def test_property_model_consistency(
-    si_double_sim_state: SimState, tmp_path: Path, prop_calculators: dict
+    si_double_sim_state: ts.SimState, tmp_path: Path, prop_calculators: dict
 ) -> None:
     """Test property models are consistent for single and multi-batch cases."""
     # Create reporters for single and multi-batch cases
@@ -743,12 +743,12 @@ def test_property_model_consistency(
 
 
 def test_reporter_with_model(
-    si_double_sim_state: SimState, tmp_path: Path, lj_model: LennardJonesModel
+    si_double_sim_state: ts.SimState, tmp_path: Path, lj_model: LennardJonesModel
 ) -> None:
     """Test TrajectoryReporter with a model argument in property calculators."""
 
     # Create a property calculator that uses the model
-    def energy_calculator(state: SimState, model: torch.nn.Module) -> torch.Tensor:
+    def energy_calculator(state: ts.SimState, model: torch.nn.Module) -> torch.Tensor:
         output = model(state)
         # Calculate a property that depends on the model
         return output["energy"]
@@ -805,7 +805,7 @@ def test_get_atoms_importerror(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
 
     traj = TorchSimTrajectory(tmp_path / "dummy.h5", mode="w")
     # Write minimal data so get_atoms can be called
-    state = SimState(
+    state = ts.SimState(
         positions=torch.zeros(1, 3),
         masses=torch.ones(1),
         cell=torch.eye(3).unsqueeze(0),
@@ -829,7 +829,7 @@ def test_write_ase_trajectory_importerror(
 
     traj = TorchSimTrajectory(tmp_path / "dummy.h5", mode="w")
     # Write minimal data so write_ase_trajectory can be called
-    state = SimState(
+    state = ts.SimState(
         positions=torch.zeros(1, 3),
         masses=torch.ones(1),
         cell=torch.eye(3).unsqueeze(0),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -4,8 +4,8 @@ import pytest
 import torch
 from ase.geometry import wrap_positions as ase_wrap_positions
 
+import torch_sim as ts
 import torch_sim.transforms as tst
-from torch_sim.state import SimState
 
 
 def test_inverse_box_scalar() -> None:
@@ -243,7 +243,7 @@ def test_translate_pretty():
     assert torch.all((translated >= 0) & (translated < 1))
 
 
-def test_pbc_wrap_batched_orthorhombic(si_double_sim_state: SimState) -> None:
+def test_pbc_wrap_batched_orthorhombic(si_double_sim_state: ts.SimState) -> None:
     """Test batched periodic boundary wrapping with orthorhombic cell."""
     # Make a copy of the state to modify positions
     state = si_double_sim_state
@@ -392,7 +392,7 @@ def test_pbc_wrap_batched_invalid_inputs(device: torch.device) -> None:
         )
 
 
-def test_pbc_wrap_batched_multi_atom(si_double_sim_state: SimState) -> None:
+def test_pbc_wrap_batched_multi_atom(si_double_sim_state: ts.SimState) -> None:
     """Test batched wrapping with realistic multi-atom system."""
     state = si_double_sim_state
 
@@ -430,7 +430,7 @@ def test_pbc_wrap_batched_multi_atom(si_double_sim_state: SimState) -> None:
 
 
 def test_pbc_wrap_batched_preserves_relative_positions(
-    si_double_sim_state: SimState,
+    si_double_sim_state: ts.SimState,
 ) -> None:
     """Test that relative positions within each batch are preserved after wrapping."""
     state = si_double_sim_state

--- a/tests/unbatched/conftest.py
+++ b/tests/unbatched/conftest.py
@@ -10,7 +10,6 @@ if typing.TYPE_CHECKING:
     from ase.calculators.calculator import Calculator
 
     from torch_sim.models.interface import ModelInterface
-    from torch_sim.state import SimState
 
 
 consistency_test_simstate_fixtures = (
@@ -61,7 +60,7 @@ def make_unbatched_model_calculator_consistency_test(
         calculator: Calculator = request.getfixturevalue(calculator_fixture_name)
 
         # Get the sim_state fixture dynamically using the name
-        sim_state: SimState = (
+        sim_state: ts.SimState = (
             request.getfixturevalue(sim_state_name).to(device, dtype).split()[0]
         )
 

--- a/tests/unbatched/test_unbatched_integrators.py
+++ b/tests/unbatched/test_unbatched_integrators.py
@@ -3,8 +3,8 @@ from typing import Any
 import pytest
 import torch
 
+import torch_sim as ts
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
-from torch_sim.state import SimState
 from torch_sim.unbatched.unbatched_integrators import (
     MDState,
     calculate_momenta,
@@ -20,7 +20,7 @@ from torch_sim.units import MetalUnits
 
 
 def test_nve_integrator(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test NVE integration conserves energy."""
     # Initialize integrator
@@ -48,7 +48,7 @@ def test_nve_integrator(
 
 
 def test_nvt_langevin_integrator(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test Langevin thermostat maintains target temperature."""
     # Initialize integrator
@@ -77,7 +77,7 @@ def test_nvt_langevin_integrator(
 
 
 def test_nvt_nose_hoover_integrator(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test Nose-Hoover chain thermostat maintains temperature."""
     # Initialize integrator
@@ -116,7 +116,7 @@ def test_nvt_nose_hoover_integrator(
 
 
 def test_npt_langevin_integrator(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test Langevin thermostat maintains target temperature."""
     # Initialize integrator
@@ -163,7 +163,7 @@ def test_npt_langevin_integrator(
 
 
 def test_integrator_state_properties(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test that all integrators preserve state properties."""
     device = ar_supercell_sim_state.positions.device
@@ -215,7 +215,7 @@ def test_integrator_state_properties(
 
 
 def test_nvt_nose_hoover_invariant(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test Nose-Hoover chain thermostat maintains temperature."""
     # Initialize integrator
@@ -248,7 +248,7 @@ def test_nvt_nose_hoover_invariant(
 
 @pytest.mark.skip(reason="NPT Nose-Hoover needs debugging")
 def test_npt_nose_hoover_invariant(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test NPT Nose-Hoover chain thermostats maintain temperature and pressure."""
     # Initialize integrator

--- a/tests/unbatched/test_unbatched_optimizers.py
+++ b/tests/unbatched/test_unbatched_optimizers.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import torch
 
-from torch_sim.state import SimState
+import torch_sim as ts
 from torch_sim.unbatched.unbatched_optimizers import (
     fire,
     frechet_cell_fire,
@@ -12,7 +12,7 @@ from torch_sim.unbatched.unbatched_optimizers import (
 
 
 def test_fire_optimizer(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test FIRE optimization of Ar FCC structure."""
     # perturb the structure
@@ -50,7 +50,7 @@ def test_fire_optimizer(
 
 
 def test_gradient_descent_optimizer(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test gradient descent optimization of Ar FCC structure."""
     # perturb the structure
@@ -77,7 +77,7 @@ def test_gradient_descent_optimizer(
 
 
 def test_unit_cell_fire_optimizer(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test FIRE optimization of Ar FCC structure."""
     # perturb the structure
@@ -121,7 +121,7 @@ def test_unit_cell_fire_optimizer(
 
 
 def test_frechet_cell_fire_optimizer(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test FIRE optimization of Ar FCC structure."""
     # perturb the structure
@@ -165,7 +165,7 @@ def test_frechet_cell_fire_optimizer(
 
 
 def test_optimizer_convergence(
-    ar_supercell_sim_state: SimState, unbatched_lj_model: Any
+    ar_supercell_sim_state: ts.SimState, unbatched_lj_model: Any
 ) -> None:
     """Test that both optimizers can reach similar final states."""
     # perturb the structure

--- a/tests/workflows/test_a2c.py
+++ b/tests/workflows/test_a2c.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from pymatgen.core.composition import Composition
 
-from torch_sim.state import SimState
+import torch_sim as ts
 from torch_sim.unbatched.models.soft_sphere import UnbatchedSoftSphereModel
 from torch_sim.unbatched.unbatched_optimizers import UnitCellFIREState
 from torch_sim.workflows import a2c
@@ -342,11 +342,11 @@ def create_test_model(
     )
 
 
-def create_test_state(positions: torch.Tensor, cell: torch.Tensor) -> SimState:
+def create_test_state(positions: torch.Tensor, cell: torch.Tensor) -> ts.SimState:
     """Create a simple simulation state for testing."""
     n_atoms = positions.shape[0]
     device = positions.device
-    return SimState(
+    return ts.SimState(
         positions=positions,
         cell=cell,
         pbc=True,

--- a/torch_sim/__init__.py
+++ b/torch_sim/__init__.py
@@ -33,9 +33,9 @@ from torch_sim.optimizers import (
     unit_cell_fire,
     unit_cell_gradient_descent,
 )
-from torch_sim.properties.correlations import CorrelationCalculator
 
-# quantities
+# quantities/properties
+from torch_sim.properties.correlations import CorrelationCalculator
 from torch_sim.quantities import calc_kinetic_energy, calc_kT
 
 # high level runners and support
@@ -48,7 +48,7 @@ from torch_sim.runners import (
 )
 
 # state and state manipulation
-from torch_sim.state import concatenate_states, initialize_state
+from torch_sim.state import SimState, concatenate_states, initialize_state
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 
 

--- a/torch_sim/io.py
+++ b/torch_sim/io.py
@@ -17,16 +17,16 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
+import torch_sim as ts
+
 
 if TYPE_CHECKING:
     from ase import Atoms
     from phonopy.structure.atoms import PhonopyAtoms
     from pymatgen.core import Structure
 
-    from torch_sim.state import SimState
 
-
-def state_to_atoms(state: "SimState") -> list["Atoms"]:
+def state_to_atoms(state: "ts.SimState") -> list["Atoms"]:
     """Convert a SimState to a list of ASE Atoms objects.
 
     Args:
@@ -72,7 +72,7 @@ def state_to_atoms(state: "SimState") -> list["Atoms"]:
     return atoms_list
 
 
-def state_to_structures(state: "SimState") -> list["Structure"]:
+def state_to_structures(state: "ts.SimState") -> list["Structure"]:
     """Convert a SimState to a list of Pymatgen Structure objects.
 
     Args:
@@ -128,7 +128,7 @@ def state_to_structures(state: "SimState") -> list["Structure"]:
     return structures
 
 
-def state_to_phonopy(state: "SimState") -> list["PhonopyAtoms"]:
+def state_to_phonopy(state: "ts.SimState") -> list["PhonopyAtoms"]:
     """Convert a SimState to a list of PhonopyAtoms objects.
 
     Args:
@@ -181,7 +181,7 @@ def atoms_to_state(
     atoms: "Atoms | list[Atoms]",
     device: torch.device,
     dtype: torch.dtype,
-) -> "SimState":
+) -> "ts.SimState":
     """Convert an ASE Atoms object or list of Atoms objects to a SimState.
 
     Args:
@@ -202,8 +202,6 @@ def atoms_to_state(
         - Input masses should be in amu
         - All systems must have consistent periodic boundary conditions
     """
-    from torch_sim.state import SimState
-
     try:
         from ase import Atoms
     except ImportError:
@@ -237,7 +235,7 @@ def atoms_to_state(
     if not all(all(a.pbc) == all(atoms_list[0].pbc) for a in atoms_list):
         raise ValueError("All systems must have the same periodic boundary conditions")
 
-    return SimState(
+    return ts.SimState(
         positions=positions,
         masses=masses,
         cell=cell,
@@ -251,7 +249,7 @@ def structures_to_state(
     structure: "Structure | list[Structure]",
     device: torch.device,
     dtype: torch.dtype,
-) -> "SimState":
+) -> "ts.SimState":
     """Create a SimState from pymatgen Structure(s).
 
     Args:
@@ -272,8 +270,6 @@ def structures_to_state(
         - Cell matrix follows ASE convention: [[ax,ay,az],[bx,by,bz],[cx,cy,cz]]
         - Assumes periodic boundary conditions from Structure
     """
-    from torch_sim.state import SimState
-
     try:
         from pymatgen.core import Structure
     except ImportError:
@@ -307,7 +303,7 @@ def structures_to_state(
         torch.arange(len(struct_list), device=device), atoms_per_batch
     )
 
-    return SimState(
+    return ts.SimState(
         positions=positions,
         masses=masses,
         cell=cell,
@@ -321,7 +317,7 @@ def phonopy_to_state(
     phonopy_atoms: "PhonopyAtoms | list[PhonopyAtoms]",
     device: torch.device,
     dtype: torch.dtype,
-) -> "SimState":
+) -> "ts.SimState":
     """Create state tensors from a PhonopyAtoms object or list of PhonopyAtoms objects.
 
     Args:
@@ -343,8 +339,6 @@ def phonopy_to_state(
         - PhonopyAtoms does not have pbc attribute for Supercells, assumes True
         - Cell matrix follows ASE convention: [[ax,ay,az],[bx,by,bz],[cx,cy,cz]]
     """
-    from torch_sim.state import SimState
-
     try:
         from phonopy.structure.atoms import PhonopyAtoms
     except ImportError:
@@ -387,7 +381,7 @@ def phonopy_to_state(
         raise ValueError("All systems must have the same periodic boundary conditions")
     """
 
-    return SimState(
+    return ts.SimState(
         positions=positions,
         masses=masses,
         cell=cell,

--- a/torch_sim/models/fairchem.py
+++ b/torch_sim/models/fairchem.py
@@ -23,8 +23,8 @@ from typing import Any
 
 import torch
 
+import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
-from torch_sim.state import SimState
 
 
 try:
@@ -315,7 +315,7 @@ class FairChemModel(torch.nn.Module, ModelInterface):
         except NotImplementedError:
             print("Unable to load checkpoint!")
 
-    def forward(self, state: SimState | StateDict) -> dict:
+    def forward(self, state: ts.SimState | StateDict) -> dict:
         """Perform forward pass to compute energies, forces, and other properties.
 
         Takes a simulation state and computes the properties implemented by the model,
@@ -338,7 +338,7 @@ class FairChemModel(torch.nn.Module, ModelInterface):
             All output tensors are detached from the computation graph.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.device != self._device:
             state = state.to(self._device)

--- a/torch_sim/models/graphpes.py
+++ b/torch_sim/models/graphpes.py
@@ -18,9 +18,9 @@ from pathlib import Path
 
 import torch
 
+import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -50,7 +50,7 @@ except ImportError:
         pass
 
 
-def state_to_atomic_graph(state: SimState, cutoff: torch.Tensor) -> AtomicGraph:
+def state_to_atomic_graph(state: ts.SimState, cutoff: torch.Tensor) -> AtomicGraph:
     """Convert a SimState object into an AtomicGraph object.
 
     Args:
@@ -117,7 +117,7 @@ class GraphPESWrapper(torch.nn.Module, ModelInterface):
         >>> from graph_pes.models import load_model
         >>> model = load_model("path/to/model.pt")
         >>> wrapper = GraphPESWrapper(model)
-        >>> state = SimState(
+        >>> state = ts.SimState(
         ...     positions=torch.randn(10, 3),
         ...     cell=torch.eye(3),
         ...     atomic_numbers=torch.randint(1, 104, (10,)),
@@ -169,7 +169,7 @@ class GraphPESWrapper(torch.nn.Module, ModelInterface):
         if self._gp_model.cutoff.item() < 0.5:
             self._memory_scales_with = "n_atoms"
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Forward pass for the GraphPESWrapper.
 
         Args:
@@ -179,8 +179,8 @@ class GraphPESWrapper(torch.nn.Module, ModelInterface):
             Dictionary containing the computed energies, forces, and stresses
             (where applicable)
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)  # type: ignore[arg-type]
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)  # type: ignore[arg-type]
 
         atomic_graph = state_to_atomic_graph(state, self._gp_model.cutoff)
         return self._gp_model.predict(atomic_graph, self._properties)  # type: ignore[return-value]

--- a/torch_sim/models/lennard_jones.py
+++ b/torch_sim/models/lennard_jones.py
@@ -26,10 +26,10 @@ Example::
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 from torch_sim.unbatched.models.lennard_jones import (
     lennard_jones_pair,
@@ -145,7 +145,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
 
     def unbatched_forward(
         self,
-        state: SimState,
+        state: ts.SimState,
     ) -> dict[str, torch.Tensor]:
         """Compute Lennard-Jones properties for a single unbatched system.
 
@@ -175,8 +175,8 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
 
             The implementation applies cutoff distance to both approaches for consistency.
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         positions = state.positions
         cell = state.row_vector_cell
@@ -276,7 +276,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
 
         return results
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute Lennard-Jones energies, forces, and stresses for a system.
 
         Main entry point for Lennard-Jones calculations that handles batched states by
@@ -315,7 +315,7 @@ class LennardJonesModel(torch.nn.Module, ModelInterface):
             stresses = results["stresses"]  # Shape: [n_atoms, 3, 3]
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.batch is None and state.cell.shape[0] > 1:
             raise ValueError("Batch can only be inferred for batch size 1.")

--- a/torch_sim/models/mace.py
+++ b/torch_sim/models/mace.py
@@ -19,6 +19,7 @@ Notes:
 
 import typing
 from collections.abc import Callable
+from enum import StrEnum
 from pathlib import Path
 
 import torch
@@ -361,3 +362,11 @@ class MaceModel(torch.nn.Module, ModelInterface):
                 results["stress"] = stress.detach()
 
         return results
+
+
+class MaceUrls(StrEnum):
+    """Checkpoint download URLs for MACE models."""
+
+    mace_mp_small = "https://github.com/ACEsuit/mace-mp/releases/download/mace_mp_0b/mace_agnesi_small.model"
+    mace_mpa_medium = "https://github.com/ACEsuit/mace-foundations/releases/download/mace_mpa_0/mace-mpa-0-medium.model"
+    mace_off_small = "https://github.com/ACEsuit/mace-off/blob/main/mace_off23/MACE-OFF23_small.model?raw=true"

--- a/torch_sim/models/mace.py
+++ b/torch_sim/models/mace.py
@@ -23,9 +23,9 @@ from pathlib import Path
 
 import torch
 
+import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -233,7 +233,7 @@ class MaceModel(torch.nn.Module, ModelInterface):
 
     def forward(  # noqa: C901
         self,
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
     ) -> dict[str, torch.Tensor]:
         """Compute energies, forces, and stresses for the given atomic systems.
 
@@ -260,7 +260,7 @@ class MaceModel(torch.nn.Module, ModelInterface):
         """
         # Extract required data from input
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         # Handle input validation for atomic numbers
         if state.atomic_numbers is None and not self.atomic_numbers_in_init:

--- a/torch_sim/models/mattersim.py
+++ b/torch_sim/models/mattersim.py
@@ -8,7 +8,6 @@ import torch
 
 import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
-from torch_sim.state import SimState
 from torch_sim.units import MetalUnits
 
 
@@ -108,7 +107,7 @@ class MatterSimModel(torch.nn.Module, ModelInterface):
             "stress",
         ]
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Perform forward pass to compute energies, forces, and other properties.
 
         Takes a simulation state and computes the properties implemented by the model,
@@ -131,7 +130,7 @@ class MatterSimModel(torch.nn.Module, ModelInterface):
             All output tensors are detached from the computation graph.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.device != self._device:
             state = state.to(self._device)

--- a/torch_sim/models/metatensor.py
+++ b/torch_sim/models/metatensor.py
@@ -16,8 +16,8 @@ from pathlib import Path
 import torch
 import vesin.torch.metatensor
 
+import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -146,7 +146,7 @@ class MetatensorModel(torch.nn.Module, ModelInterface):
 
     def forward(  # noqa: C901, PLR0915
         self,
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
     ) -> dict[str, torch.Tensor]:
         """Compute energies, forces, and stresses for the given atomic systems.
 
@@ -168,7 +168,7 @@ class MetatensorModel(torch.nn.Module, ModelInterface):
         """
         # Extract required data from input
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         # Input validation is already done inside the forward method of the
         # MetatensorAtomisticModel class, so we don't need to do it again here.

--- a/torch_sim/models/morse.py
+++ b/torch_sim/models/morse.py
@@ -27,10 +27,10 @@ Notes:
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 from torch_sim.unbatched.models.morse import morse_pair, morse_pair_force
 
@@ -150,7 +150,9 @@ class MorseModel(torch.nn.Module, ModelInterface):
         self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
         self.alpha = torch.tensor(alpha, dtype=self.dtype, device=self.device)
 
-    def unbatched_forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def unbatched_forward(
+        self, state: ts.SimState | StateDict
+    ) -> dict[str, torch.Tensor]:
         """Compute Morse potential properties for a single unbatched system.
 
         Internal implementation that processes a single, non-batched simulation state.
@@ -178,7 +180,7 @@ class MorseModel(torch.nn.Module, ModelInterface):
             In both cases, interactions are truncated at the cutoff distance.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         positions = state.positions
         cell = state.row_vector_cell
@@ -264,7 +266,7 @@ class MorseModel(torch.nn.Module, ModelInterface):
 
         return results
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute Morse potential energies, forces, and stresses for a system.
 
         Main entry point for Morse potential calculations that handles batched states
@@ -298,7 +300,7 @@ class MorseModel(torch.nn.Module, ModelInterface):
             ```
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.batch is None and state.cell.shape[0] > 1:
             raise ValueError("Batch can only be inferred for batch size 1.")

--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -20,9 +20,9 @@ from pathlib import Path
 
 import torch
 
+import torch_sim as ts
 from torch_sim.elastic import voigt_6_to_full_3x3_stress
 from torch_sim.models.interface import ModelInterface
-from torch_sim.state import SimState
 
 
 try:
@@ -64,7 +64,7 @@ if typing.TYPE_CHECKING:
 
 
 def state_to_atom_graphs(  # noqa: PLR0915
-    state: SimState,
+    state: ts.SimState,
     *,
     wrap: bool = True,
     edge_method: EdgeCreationMethod | None = None,
@@ -360,7 +360,7 @@ class OrbModel(torch.nn.Module, ModelInterface):
         if self.conservative:
             self.implemented_properties.extend(["forces", "stress"])
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Perform forward pass to compute energies, forces, and other properties.
 
         Takes a simulation state and computes the properties implemented by the model,
@@ -383,7 +383,7 @@ class OrbModel(torch.nn.Module, ModelInterface):
             All output tensors are detached from the computation graph.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.device != self._device:
             state = state.to(self._device)

--- a/torch_sim/models/sevennet.py
+++ b/torch_sim/models/sevennet.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING
 
 import torch
 
+import torch_sim as ts
 from torch_sim.elastic import voigt_6_to_full_3x3_stress
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 
 
 if TYPE_CHECKING:
@@ -147,7 +147,7 @@ class SevenNetModel(torch.nn.Module, ModelInterface):
             "stress",
         ]
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Perform forward pass to compute energies, forces, and other properties.
 
         Takes a simulation state and computes the properties implemented by the model,
@@ -170,7 +170,7 @@ class SevenNetModel(torch.nn.Module, ModelInterface):
             All output tensors are detached from the computation graph.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.device != self._device:
             state = state.to(self._device)

--- a/torch_sim/models/soft_sphere.py
+++ b/torch_sim/models/soft_sphere.py
@@ -44,10 +44,10 @@ Example::
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 from torch_sim.unbatched.models.soft_sphere import (
     soft_sphere_pair,
@@ -101,7 +101,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
 
         # Get forces for a system with periodic boundary conditions
         results = colloid_model(
-            SimState(
+            ts.SimState(
                 positions=positions,
                 cell=box_vectors,
                 pbc=torch.tensor([True, True, True]),
@@ -183,7 +183,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
 
     def unbatched_forward(
         self,
-        state: SimState,
+        state: ts.SimState,
     ) -> dict[str, torch.Tensor]:
         """Compute energies and forces for a single unbatched system.
 
@@ -212,7 +212,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
             the cutoff distance.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         positions = state.positions
         cell = state.row_vector_cell
@@ -308,7 +308,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
 
         return results
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute soft sphere potential energies, forces, and stresses for a system.
 
         Main entry point for soft sphere potential calculations that handles batched
@@ -343,7 +343,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
             ```
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         # Handle batch indices if not provided
         if state.batch is None and state.cell.shape[0] > 1:
@@ -584,7 +584,7 @@ class SoftSphereMultiModel(torch.nn.Module):
 
     def unbatched_forward(  # noqa: PLR0915
         self,
-        state: SimState,
+        state: ts.SimState,
         species: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         """Compute energies and forces for a single unbatched system with multiple
@@ -620,8 +620,8 @@ class SoftSphereMultiModel(torch.nn.Module):
             of the two particles.
         """
         # Convert inputs to proper device/dtype and handle species
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         if species is not None:
             species = species.to(device=self.device, dtype=torch.long)
@@ -732,7 +732,7 @@ class SoftSphereMultiModel(torch.nn.Module):
 
         return results
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute soft sphere potential properties for multi-component systems.
 
         Main entry point for multi-species soft sphere calculations that handles
@@ -777,8 +777,8 @@ class SoftSphereMultiModel(torch.nn.Module):
             This method requires species information either provided during initialization
             or included in the state object's metadata.
         """
-        if not isinstance(state, SimState):
-            state = SimState(
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(
                 **state, pbc=self.pbc, masses=torch.ones_like(state["positions"])
             )
         elif state.pbc != self.pbc:

--- a/torch_sim/properties/__init__.py
+++ b/torch_sim/properties/__init__.py
@@ -6,7 +6,5 @@ Currently includes:
 - VelocityAutoCorrelation: Calculator for velocity autocorrelation.
 """
 
+# ruff: noqa: F401
 from .correlations import CorrelationCalculator, VelocityAutoCorrelation
-
-
-__all__ = ["CorrelationCalculator", "VelocityAutoCorrelation"]

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -386,7 +386,9 @@ def _normalize_batch_indices(
 
 
 def state_to_device(
-    state: SimState, device: torch.device | None = None, dtype: torch.dtype | None = None
+    state: SimState,
+    device: torch.device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Self:
     """Convert the SimState to a new device and dtype.
 

--- a/torch_sim/unbatched/models/lennard_jones.py
+++ b/torch_sim/unbatched/models/lennard_jones.py
@@ -2,10 +2,11 @@
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.unbatched.unbatched_integrators import SimState, StateDict
+from torch_sim.unbatched.unbatched_integrators import StateDict
 
 
 # Default parameter values defined at module level
@@ -146,7 +147,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
         self.cutoff = torch.tensor(cutoff or 2.5 * sigma, dtype=dtype, device=self.device)
         self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self.device)
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
 
         Args:
@@ -157,7 +158,7 @@ class UnbatchedLennardJonesModel(torch.nn.Module, ModelInterface):
             A dictionary containing the energy, forces, and stresses
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         cell = state.row_vector_cell
         positions = state.positions

--- a/torch_sim/unbatched/models/mace.py
+++ b/torch_sim/unbatched/models/mace.py
@@ -10,9 +10,9 @@ import torch
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.tools import atomic_numbers_to_indices, to_one_hot, utils
 
+import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -154,7 +154,7 @@ class UnbatchedMaceModel(torch.nn.Module, ModelInterface):
 
     def forward(  # noqa: C901
         self,
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
     ) -> dict[str, torch.Tensor]:
         """Compute the energy of the system given atomic positions and box vectors.
 
@@ -169,7 +169,7 @@ class UnbatchedMaceModel(torch.nn.Module, ModelInterface):
                 forces, and stress of the system.
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         if state.batch is not None and state.batch.max() > 0:
             raise ValueError("UnbatchedMaceModel does not support batched systems.")

--- a/torch_sim/unbatched/models/morse.py
+++ b/torch_sim/unbatched/models/morse.py
@@ -2,10 +2,10 @@
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -142,7 +142,7 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
         self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
         self.alpha = torch.tensor(alpha, dtype=self.dtype, device=self.device)
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
 
         Args:
@@ -152,7 +152,7 @@ class UnbatchedMorseModel(torch.nn.Module, ModelInterface):
             Dictionary containing computed properties (energy, forces, stress, etc.)
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         positions = state.positions
         cell = state.row_vector_cell

--- a/torch_sim/unbatched/models/particle_life.py
+++ b/torch_sim/unbatched/models/particle_life.py
@@ -2,10 +2,10 @@
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 
 
 DEFAULT_BETA = torch.tensor(0.3)
@@ -124,7 +124,7 @@ class UnbatchedParticleLifeModel(torch.nn.Module, ModelInterface):
         )
         self.epsilon = torch.tensor(epsilon, dtype=self.dtype, device=self.device)
 
-    def forward(self, state: SimState) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState) -> dict[str, torch.Tensor]:
         """Compute energies and forces.
 
         Args:
@@ -136,7 +136,7 @@ class UnbatchedParticleLifeModel(torch.nn.Module, ModelInterface):
         """
         # Extract required data from input
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         positions = state.positions
         cell = state.row_vector_cell

--- a/torch_sim/unbatched/models/soft_sphere.py
+++ b/torch_sim/unbatched/models/soft_sphere.py
@@ -2,10 +2,10 @@
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import vesin_nl_ts
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
@@ -131,7 +131,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
         self.epsilon = torch.tensor(epsilon, dtype=dtype, device=self.device)
         self.alpha = torch.tensor(alpha, dtype=dtype, device=self.device)
 
-    def forward(self, state: SimState | StateDict) -> dict[str, torch.Tensor]:
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:
         """Compute energies and forces for a single system.
 
         Args:
@@ -142,7 +142,7 @@ class UnbatchedSoftSphereModel(torch.nn.Module, ModelInterface):
             A dictionary containing the energy, forces, and stresses
         """
         if isinstance(state, dict):
-            state = SimState(**state, masses=torch.ones_like(state["positions"]))
+            state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
         positions = state.positions
         cell = state.row_vector_cell

--- a/torch_sim/unbatched/unbatched_integrators.py
+++ b/torch_sim/unbatched/unbatched_integrators.py
@@ -6,14 +6,14 @@ from typing import Any
 
 import torch
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.quantities import calc_kinetic_energy, count_dof
-from torch_sim.state import SimState
 from torch_sim.typing import StateDict
 
 
 @dataclass
-class MDState(SimState):
+class MDState(ts.SimState):
     """State information for MD.
 
     This class represents the complete state of a molecular system being integrated
@@ -200,7 +200,7 @@ def nve(
     dt: torch.Tensor,
     kT: torch.Tensor,
 ) -> tuple[
-    Callable[[SimState | dict, torch.Tensor], MDState],
+    Callable[[ts.SimState | dict, torch.Tensor], MDState],
     Callable[[MDState, torch.Tensor], MDState],
 ]:
     """Initialize and return an NVE (microcanonical) integrator.
@@ -216,7 +216,7 @@ def nve(
 
     Returns:
         tuple:
-            - Callable[[SimState | StateDict, torch.Tensor], MDState]: Function to
+            - Callable[[ts.SimState | StateDict, torch.Tensor], MDState]: Function to
               initialize the MDState from input data and kT
             - Callable[[MDState, torch.Tensor], MDState]: Update function that evolves
               system by one timestep
@@ -230,7 +230,7 @@ def nve(
     device, dtype = model.device, model.dtype
 
     def nve_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         kT: torch.Tensor = kT,
         seed: int | None = None,
         **kwargs: Any,
@@ -248,8 +248,8 @@ def nve(
             MDState: Initialized state for NVE integration
         """
         # Extract required data from input
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -319,7 +319,7 @@ def nvt_langevin(
     kT: torch.Tensor,
     gamma: torch.Tensor | None = None,
 ) -> tuple[
-    Callable[[SimState | StateDict, torch.Tensor], MDState],
+    Callable[[ts.SimState | StateDict, torch.Tensor], MDState],
     Callable[[MDState, torch.Tensor], MDState],
 ]:
     """Initialize and return an NVT (canonical) integrator using Langevin dynamics.
@@ -336,7 +336,7 @@ def nvt_langevin(
 
     Returns:
         tuple:
-            - Callable[[SimState | StateDict, torch.Tensor], MDState]: Function to
+            - Callable[[ts.SimState | StateDict, torch.Tensor], MDState]: Function to
               initialize the MDState from input data and kT
             - Callable[[MDState, torch.Tensor], MDState]: Update function that evolves
               system by one timestep
@@ -397,7 +397,7 @@ def nvt_langevin(
         return state
 
     def langevin_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         kT: torch.Tensor = kT,
         seed: int | None = None,
         **kwargs: Any,
@@ -414,8 +414,8 @@ def nvt_langevin(
         Returns:
             MDState: Initialized state for NVT Langevin integration
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -489,7 +489,7 @@ def nvt_langevin(
 
 
 @dataclass
-class NPTLangevinState(SimState):
+class NPTLangevinState(ts.SimState):
     """State information for an NPT system with Langevin dynamics.
 
     This class represents the complete state of a molecular system being integrated
@@ -537,7 +537,7 @@ def npt_langevin(  # noqa: C901, PLR0915
     cell_alpha: torch.Tensor | None = None,
     b_tau: torch.Tensor | None = None,
 ) -> tuple[
-    Callable[[SimState | StateDict, torch.Tensor], MDState],
+    Callable[[ts.SimState | StateDict, torch.Tensor], MDState],
     Callable[[MDState, torch.Tensor], MDState],
 ]:
     """Initialize and return an NPT (canonical) integrator using Langevin dynamics.
@@ -557,7 +557,7 @@ def npt_langevin(  # noqa: C901, PLR0915
 
     Returns:
         tuple:
-            - Callable[[SimState | StateDict, torch.Tensor], MDState]: Function to
+            - Callable[[ts.SimState | StateDict, torch.Tensor], MDState]: Function to
               initialize the MDState from input data and kT
             - Callable[[MDState, torch.Tensor], MDState]: Update function that evolves
               system by one timestep
@@ -876,7 +876,7 @@ def npt_langevin(  # noqa: C901, PLR0915
         return state
 
     def npt_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         kT: torch.Tensor = kT,
         device: torch.device = device,
         dtype: torch.dtype = dtype,
@@ -901,8 +901,8 @@ def npt_langevin(  # noqa: C901, PLR0915
             MDState: Initialized state for NPT integration
         """
         # Convert dictionary to BaseState if needed
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -1347,7 +1347,9 @@ def nvt_nose_hoover(
     chain_steps: int = 3,
     sy_steps: int = 3,
 ) -> tuple[
-    Callable[[SimState | StateDict, torch.Tensor, int | None, Any], NVTNoseHooverState],
+    Callable[
+        [ts.SimState | StateDict, torch.Tensor, int | None, Any], NVTNoseHooverState
+    ],
     Callable[[NVTNoseHooverState, torch.Tensor], NVTNoseHooverState],
 ]:
     """Initialize NVT Nose-Hoover chain thermostat integration.
@@ -1393,7 +1395,7 @@ def nvt_nose_hoover(
     device, dtype = model.device, model.dtype
 
     def nvt_nose_hoover_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         kT: torch.Tensor = kT,
         tau: torch.Tensor | None = None,
         seed: int | None = None,
@@ -1421,8 +1423,8 @@ def nvt_nose_hoover(
             dt, chain_length, chain_steps, sy_steps, tau
         )
 
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -1659,7 +1661,7 @@ def npt_nose_hoover(  # noqa: C901, PLR0915
     chain_steps: int = 2,
     sy_steps: int = 3,
 ) -> tuple[
-    Callable[[SimState | StateDict], NPTNoseHooverState],
+    Callable[[ts.SimState | StateDict], NPTNoseHooverState],
     Callable[[NPTNoseHooverState, torch.Tensor], NPTNoseHooverState],
 ]:
     """Create an NPT simulation with Nose-Hoover chain thermostats.
@@ -1678,7 +1680,7 @@ def npt_nose_hoover(  # noqa: C901, PLR0915
 
     Returns:
         tuple:
-            - Callable[[SimState | StateDict], NPTNoseHooverState]: Initialization
+            - Callable[[ts.SimState | StateDict], NPTNoseHooverState]: Initialization
               function
             - Callable[[NPTNoseHooverState, torch.Tensor], NPTNoseHooverState]: Update
               function
@@ -2026,7 +2028,7 @@ def npt_nose_hoover(  # noqa: C901, PLR0915
         return state
 
     def npt_nose_hoover_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         kT: torch.Tensor = kT,
         t_tau: torch.Tensor | None = None,
         b_tau: torch.Tensor | None = None,
@@ -2085,8 +2087,8 @@ def npt_nose_hoover(  # noqa: C901, PLR0915
             dt, chain_length, chain_steps, sy_steps, t_tau
         )
 
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:

--- a/torch_sim/unbatched/unbatched_optimizers.py
+++ b/torch_sim/unbatched/unbatched_optimizers.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import torch
 
+import torch_sim as ts
 import torch_sim.math as tsm
 from torch_sim.state import DeformGradMixin, SimState
 from torch_sim.typing import StateDict
@@ -65,7 +66,7 @@ def gradient_descent(
     if not isinstance(lr, torch.Tensor):
         lr = torch.tensor(lr, device=device, dtype=dtype)
 
-    def gd_init(state: SimState | StateDict, **kwargs) -> GDState:
+    def gd_init(state: ts.SimState | StateDict, **kwargs) -> GDState:
         """Initialize the gradient descent optimizer state.
 
         Args:
@@ -75,8 +76,8 @@ def gradient_descent(
         Returns:
             Initial GDState with system configuration and forces
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -161,7 +162,9 @@ def fire(
     f_alpha: float = 0.99,
     alpha_start: float = 0.1,
     eps: float = 1e-8,
-) -> tuple[Callable[[SimState | StateDict], FIREState], Callable[[FIREState], FIREState]]:
+) -> tuple[
+    Callable[[ts.SimState | StateDict], FIREState], Callable[[FIREState], FIREState]
+]:
     """Initialize a FIRE (Fast Inertial Relaxation Engine) optimization.
 
     FIRE is a molecular dynamics-based optimization algorithm that combines velocity
@@ -202,7 +205,7 @@ def fire(
         torch.as_tensor(p, device=device, dtype=dtype) for p in params
     ]
 
-    def fire_init(state: SimState | StateDict, **kwargs) -> FIREState:
+    def fire_init(state: ts.SimState | StateDict, **kwargs) -> FIREState:
         """Initialize the FIRE optimizer state.
 
         Args:
@@ -212,8 +215,8 @@ def fire(
         Returns:
             Initial FIREState with system configuration and forces
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -322,7 +325,9 @@ def fire_ase(  # noqa: C901, PLR0915
     alpha_start: float = 0.1,
     f_alpha: float = 0.99,
     downhill_check: bool = False,
-) -> tuple[Callable[[SimState | StateDict], FIREState], Callable[[FIREState], FIREState]]:
+) -> tuple[
+    Callable[[ts.SimState | StateDict], FIREState], Callable[[FIREState], FIREState]
+]:
     """Initialize a FIRE (Fast Inertial Relaxation Engine) optimization following
     ASE's implementation.
 
@@ -384,7 +389,7 @@ def fire_ase(  # noqa: C901, PLR0915
         torch.as_tensor(p, device=device, dtype=dtype) for p in params
     ]
 
-    def fire_init(state: SimState | StateDict, **kwargs) -> FIREState:
+    def fire_init(state: ts.SimState | StateDict, **kwargs) -> FIREState:
         """Initialize the FIRE optimizer state.
 
         Args:
@@ -394,8 +399,8 @@ def fire_ase(  # noqa: C901, PLR0915
         Returns:
             Initial FIREState with system configuration and forces
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         # Check if there is an extra batch dimension
         if state.cell.dim() == 3:
@@ -556,7 +561,7 @@ def unit_cell_fire(  # noqa: PLR0915, C901
     scalar_pressure: float = 0.0,
     cell_factor: float | None = None,
 ) -> tuple[
-    Callable[[SimState | StateDict], UnitCellFIREState],
+    Callable[[ts.SimState | StateDict], UnitCellFIREState],
     Callable[[UnitCellFIREState], UnitCellFIREState],
 ]:
     """Initialize a FIRE optimization with unit cell.
@@ -591,7 +596,7 @@ def unit_cell_fire(  # noqa: PLR0915, C901
     )
 
     def fire_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         cell_factor: torch.Tensor | None = cell_factor,
         scalar_pressure: float = scalar_pressure,
         **kwargs,
@@ -607,8 +612,8 @@ def unit_cell_fire(  # noqa: PLR0915, C901
         Returns:
             Initial UnitCellFIREState with system configuration and forces
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         atomic_numbers = kwargs.get("atomic_numbers", state.atomic_numbers)
 
@@ -857,7 +862,7 @@ def frechet_cell_fire(  # noqa: PLR0915, C901
     scalar_pressure: float = 0.0,
     cell_factor: float | None = None,
 ) -> tuple[
-    Callable[[SimState | StateDict], FrechetCellFIREState],
+    Callable[[ts.SimState | StateDict], FrechetCellFIREState],
     Callable[[FrechetCellFIREState], FrechetCellFIREState],
 ]:
     """Initialize a FIRE optimization with Frechet cell parameterization.
@@ -900,7 +905,7 @@ def frechet_cell_fire(  # noqa: PLR0915, C901
     )
 
     def fire_init(
-        state: SimState | StateDict,
+        state: ts.SimState | StateDict,
         cell_factor: float | None = cell_factor,
         scalar_pressure: float = scalar_pressure,
         **kwargs,
@@ -916,8 +921,8 @@ def frechet_cell_fire(  # noqa: PLR0915, C901
         Returns:
             Initial FrechetCellFIREState with system configuration and forces
         """
-        if not isinstance(state, SimState):
-            state = SimState(**state)
+        if not isinstance(state, ts.SimState):
+            state = ts.SimState(**state)
 
         atomic_numbers = kwargs.get("atomic_numbers", state.atomic_numbers)
 

--- a/torch_sim/workflows/a2c.py
+++ b/torch_sim/workflows/a2c.py
@@ -15,9 +15,9 @@ import numpy as np
 import torch
 from pymatgen.core.composition import Composition
 
+import torch_sim as ts
 from torch_sim import transforms
 from torch_sim.optimizers import unit_cell_fire as batched_unit_cell_fire
-from torch_sim.state import SimState
 from torch_sim.unbatched.models.soft_sphere import (
     UnbatchedSoftSphereModel,
     UnbatchedSoftSphereMultiModel,
@@ -307,7 +307,7 @@ def random_packed_structure(
         atomic_numbers = torch.ones_like(positions_cart, device=device, dtype=torch.int)
 
         # Set up FIRE optimizer with unit masses
-        state = SimState(
+        state = ts.SimState(
             positions=positions_cart,
             masses=torch.ones(N_atoms, device=device, dtype=dtype),
             atomic_numbers=atomic_numbers,
@@ -435,7 +435,7 @@ def random_packed_structure_multi(
         # Dummy atomic numbers
         atomic_numbers = torch.ones_like(positions_cart, device=device, dtype=torch.int)
 
-        state_dict = SimState(
+        state_dict = ts.SimState(
             positions=positions_cart,
             masses=torch.ones(N_atoms, device=device, dtype=dtype),
             atomic_numbers=atomic_numbers,
@@ -710,7 +710,7 @@ def get_target_temperature(
 
 
 def get_unit_cell_relaxed_structure(
-    state: SimState,
+    state: ts.SimState,
     model: torch.nn.Module,
     max_iter: int = 200,
 ) -> tuple[UnitCellFIREState, dict]:
@@ -782,7 +782,7 @@ def get_unit_cell_relaxed_structure(
 
 
 def get_unit_cell_relaxed_structure_batched(
-    state: SimState,
+    state: ts.SimState,
     model: torch.nn.Module,
     max_iter: int = 200,
 ) -> tuple[UnitCellFIREState, dict]:
@@ -856,7 +856,7 @@ def get_unit_cell_relaxed_structure_batched(
 
 
 def get_relaxed_structure(
-    state: SimState,
+    state: ts.SimState,
     model: torch.nn.Module,
     max_iter: int = 200,
 ) -> tuple[FIREState, dict]:


### PR DESCRIPTION
add `from torch_sim.state import SimState` in `torch_sim/__init__.py`. makes `SimState` accessible as

```py
import torch_sim as ts

ts.SimState
```

for better ergonomics. related PR (as in should maybe have been part of) https://github.com/Radical-AI/torch-sim/pull/52