### PR TITLE
Fix discrepancies between `FIRE` optimisations in `ASE` and `torch-sim` 

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,5 +18,3 @@ jobs:
         with:
           # ignore ipynb links since they're generated on the fly
           args: --exclude-path dist --exclude '\.ipynb$' --accept 100..=103,200..=299,403,429,500 -- ./**/*.{md,py,yml,json}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
+++ b/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
@@ -171,7 +171,9 @@ def run_optimization_ts(  # noqa: PLR0915
     convergence_steps = torch.full(
         (total_structures,), -1, dtype=torch.long, device=device
     )
-    convergence_fn = ts.generate_force_convergence_fn(force_tol=force_tol, include_cell_forces=ts_use_frechet)
+    convergence_fn = ts.generate_force_convergence_fn(
+        force_tol=force_tol, include_cell_forces=ts_use_frechet
+    )
     converged_tensor_global = torch.zeros(
         total_structures, dtype=torch.bool, device=device
     )

--- a/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
+++ b/examples/scripts/7_Others/7.6_Compare_ASE_to_VV_FIRE.py
@@ -171,7 +171,7 @@ def run_optimization_ts(  # noqa: PLR0915
     convergence_steps = torch.full(
         (total_structures,), -1, dtype=torch.long, device=device
     )
-    convergence_fn = ts.generate_force_convergence_fn(force_tol=force_tol)
+    convergence_fn = ts.generate_force_convergence_fn(force_tol=force_tol, include_cell_forces=ts_use_frechet)
     converged_tensor_global = torch.zeros(
         total_structures, dtype=torch.bool, device=device
     )
@@ -194,7 +194,7 @@ def run_optimization_ts(  # noqa: PLR0915
             current_indices_list, dtype=torch.long, device=device
         )
 
-        steps_this_round = 10
+        steps_this_round = 1
         for _ in range(steps_this_round):
             opt_state = update_fn_opt(opt_state)
         global_step += steps_this_round

--- a/tests/test_optimizers_vs_ase.py
+++ b/tests/test_optimizers_vs_ase.py
@@ -1,4 +1,3 @@
-import copy
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -17,6 +16,65 @@ if TYPE_CHECKING:
     from mace.calculators import MACECalculator
 
 
+def _compare_ase_and_ts_states(
+    ts_current_system_state: ts.state.SimState,
+    filtered_ase_atoms_for_run: Any,
+    tolerances: dict[str, float],
+    current_test_id: str,
+) -> None:
+    structure_matcher = StructureMatcher(
+        ltol=tolerances["lattice_tol"],
+        stol=tolerances["site_tol"],
+        angle_tol=tolerances["angle_tol"],
+        scale=False,
+    )
+
+    tkwargs = {
+        "device": ts_current_system_state.device,
+        "dtype": ts_current_system_state.dtype,
+    }
+
+    final_custom_energy = ts_current_system_state.energy.item()
+    final_custom_forces_max = (
+        torch.norm(ts_current_system_state.forces, dim=-1).max().item()
+    )
+
+    # Convert torch-sim state to pymatgen Structure
+    ts_structure = state_to_structures(ts_current_system_state)[0]
+
+    # Convert ASE atoms to pymatgen Structure
+    final_ase_atoms = filtered_ase_atoms_for_run.atoms
+    final_ase_energy = final_ase_atoms.get_potential_energy()
+    ase_forces_raw = final_ase_atoms.get_forces()
+    final_ase_forces_max = torch.norm(
+        torch.tensor(ase_forces_raw, **tkwargs), dim=-1
+    ).max()
+    ase_structure = state_to_structures(atoms_to_state(final_ase_atoms, **tkwargs))[0]
+
+    # Compare energies
+    energy_diff = abs(final_custom_energy - final_ase_energy)
+    assert energy_diff < tolerances["energy"], (
+        f"{current_test_id}: Final energies differ significantly: "
+        f"torch-sim={final_custom_energy:.6f}, ASE={final_ase_energy:.6f}, "
+        f"Diff={energy_diff:.2e}"
+    )
+
+    # Compare forces
+    force_max_diff = abs(final_custom_forces_max - final_ase_forces_max)
+    assert force_max_diff < tolerances["force_max"], (
+        f"{current_test_id}: Max forces differ significantly: "
+        f"torch-sim={final_custom_forces_max:.4f}, ASE={final_ase_forces_max:.4f}, "
+        f"Diff={force_max_diff:.2e}"
+    )
+
+    # Compare structures using StructureMatcher
+    assert structure_matcher.fit(ts_structure, ase_structure), (
+        f"{current_test_id}: Structures do not match according to StructureMatcher, "
+        f"{ts_structure=}"
+        f"{ase_structure=}"
+    )
+
+
 def _run_and_compare_optimizers(
     initial_sim_state_fixture: ts.state.SimState,
     torchsim_mace_mpa: MaceModel,
@@ -33,14 +91,7 @@ def _run_and_compare_optimizers(
     dtype = torch.float64
     device = torchsim_mace_mpa.device
 
-    ts_current_system_state = copy.deepcopy(initial_sim_state_fixture).to(
-        dtype=dtype, device=device
-    )
-    ts_current_system_state.positions = (
-        ts_current_system_state.positions.detach().requires_grad_()
-    )
-    ts_current_system_state.cell = ts_current_system_state.cell.detach().requires_grad_()
-    ts_optimizer_state = None
+    ts_current_system_state = initial_sim_state_fixture.clone()
 
     optimizer_builders = {
         "frechet": frechet_cell_fire,
@@ -55,7 +106,7 @@ def _run_and_compare_optimizers(
     )
 
     ase_atoms_for_run = state_to_atoms(
-        copy.deepcopy(initial_sim_state_fixture).to(dtype=dtype, device=device)
+        initial_sim_state_fixture.clone().to(dtype=dtype, device=device)
     )[0]
     ase_atoms_for_run.calc = ase_mace_mpa
     filtered_ase_atoms_for_run = ase_filter_class(ase_atoms_for_run)
@@ -64,81 +115,41 @@ def _run_and_compare_optimizers(
     last_checkpoint_step_count = 0
     convergence_fn = ts.generate_force_convergence_fn(force_tol=force_tol)
 
-    structure_matcher = StructureMatcher(
-        ltol=tolerances["lattice_tol"],
-        stol=tolerances["site_tol"],
-        angle_tol=tolerances["angle_tol"],
-        scale=False,
+    results = torchsim_mace_mpa(ts_current_system_state)
+    ts_initial_system_state = ts_current_system_state.clone()
+    ts_initial_system_state.forces = results["forces"]
+    ts_initial_system_state.energy = results["energy"]
+    ase_atoms_for_run.calc.calculate(ase_atoms_for_run)
+
+    _compare_ase_and_ts_states(
+        ts_initial_system_state,
+        filtered_ase_atoms_for_run,
+        tolerances,
+        f"{test_id_prefix} (Initial)",
     )
 
     for checkpoint_step in checkpoints:
         steps_for_current_segment = checkpoint_step - last_checkpoint_step_count
 
         if steps_for_current_segment > 0:
-            # Ensure requires_grad is set for the input to ts.optimize
-            # ts.optimize is expected to return a state suitable for further optimization
-            # if optimizer_state is passed.
-            ts_current_system_state.positions = (
-                ts_current_system_state.positions.detach().requires_grad_()
-            )
-            ts_current_system_state.cell = (
-                ts_current_system_state.cell.detach().requires_grad_()
-            )
-            new_ts_state_and_optimizer_state = ts.optimize(
+            updated_ts_state = ts.optimize(
                 system=ts_current_system_state,
                 model=torchsim_mace_mpa,
                 optimizer=optimizer_callable_for_ts_optimize,
                 max_steps=steps_for_current_segment,
                 convergence_fn=convergence_fn,
-                optimizer_state=ts_optimizer_state,
             )
-            ts_current_system_state = new_ts_state_and_optimizer_state
-            ts_optimizer_state = new_ts_state_and_optimizer_state
+            ts_current_system_state = updated_ts_state.clone()
 
             ase_optimizer.run(fmax=force_tol, steps=steps_for_current_segment)
 
         current_test_id = f"{test_id_prefix} (Step {checkpoint_step})"
 
-        final_custom_energy = ts_current_system_state.energy.item()
-        final_custom_forces_max = (
-            torch.norm(ts_current_system_state.forces, dim=-1).max().item()
-        )
-
-        # Convert torch-sim state to pymatgen Structure
-        ts_structure = state_to_structures(ts_current_system_state)[0]
-
-        # Convert ASE atoms to pymatgen Structure
-        final_ase_atoms = filtered_ase_atoms_for_run.atoms
-        final_ase_energy = final_ase_atoms.get_potential_energy()
-        ase_forces_raw = final_ase_atoms.get_forces()
-        final_ase_forces_max = torch.norm(
-            torch.tensor(ase_forces_raw, device=device, dtype=dtype), dim=-1
-        ).max()
-        ase_structure = state_to_structures(
-            atoms_to_state(final_ase_atoms, device, dtype)
-        )[0]
-
-        # Compare energies
-        energy_diff = abs(final_custom_energy - final_ase_energy)
-        assert energy_diff < tolerances["energy"], (
-            f"{current_test_id}: Final energies differ significantly: "
-            f"torch-sim={final_custom_energy:.6f}, ASE={final_ase_energy:.6f}, "
-            f"Diff={energy_diff:.2e}"
-        )
-
-        # Compare forces
-        force_max_diff = abs(final_custom_forces_max - final_ase_forces_max)
-        assert force_max_diff < tolerances["force_max"], (
-            f"{current_test_id}: Max forces differ significantly: "
-            f"torch-sim={final_custom_forces_max:.4f}, ASE={final_ase_forces_max:.4f}, "
-            f"Diff={force_max_diff:.2e}"
-        )
-
-        # Compare structures using StructureMatcher
-        assert structure_matcher.fit(ts_structure, ase_structure), (
-            f"{current_test_id}: Structures do not match according to StructureMatcher, "
-            f"{ts_structure=}"
-            f"{ase_structure=}"
+        _compare_ase_and_ts_states(
+            ts_current_system_state,
+            filtered_ase_atoms_for_run,
+            tolerances,
+            current_test_id,
         )
 
         last_checkpoint_step_count = checkpoint_step
@@ -159,7 +170,7 @@ def _run_and_compare_optimizers(
             "rattled_sio2_sim_state",
             "frechet",
             FrechetCellFilter,
-            [33, 66, 100],
+            [1, 33, 66, 100],
             0.02,
             {
                 "energy": 1e-2,
@@ -174,7 +185,7 @@ def _run_and_compare_optimizers(
             "osn2_sim_state",
             "frechet",
             FrechetCellFilter,
-            [16, 33, 50],
+            [1, 16, 33, 50],
             0.02,
             {
                 "energy": 1e-2,
@@ -189,7 +200,7 @@ def _run_and_compare_optimizers(
             "distorted_fcc_al_conventional_sim_state",
             "frechet",
             FrechetCellFilter,
-            [33, 66, 100],
+            [1, 33, 66, 100],
             0.01,
             {
                 "energy": 1e-2,
@@ -204,7 +215,7 @@ def _run_and_compare_optimizers(
             "distorted_fcc_al_conventional_sim_state",
             "unit_cell",
             UnitCellFilter,
-            [33, 66, 100],
+            [1, 33, 66, 100],
             0.01,
             {
                 "energy": 1e-2,
@@ -219,7 +230,7 @@ def _run_and_compare_optimizers(
             "rattled_sio2_sim_state",
             "unit_cell",
             UnitCellFilter,
-            [33, 66, 100],
+            [1, 33, 66, 100],
             0.02,
             {
                 "energy": 1e-2,
@@ -229,6 +240,21 @@ def _run_and_compare_optimizers(
                 "angle_tol": 1e-1,
             },
             "SiO2 (UnitCell)",
+        ),
+        (
+            "osn2_sim_state",
+            "unit_cell",
+            UnitCellFilter,
+            [1, 16, 33, 50],
+            0.02,
+            {
+                "energy": 1e-2,
+                "force_max": 5e-2,
+                "lattice_tol": 3e-2,
+                "site_tol": 3e-2,
+                "angle_tol": 1e-1,
+            },
+            "OsN2 (UnitCell)",
         ),
     ],
 )

--- a/tests/test_optimizers_vs_ase.py
+++ b/tests/test_optimizers_vs_ase.py
@@ -113,7 +113,9 @@ def _run_and_compare_optimizers(
     ase_optimizer = FIRE(filtered_ase_atoms_for_run, logfile=None)
 
     last_checkpoint_step_count = 0
-    convergence_fn = ts.generate_force_convergence_fn(force_tol=force_tol)
+    convergence_fn = ts.generate_force_convergence_fn(
+        force_tol=force_tol, include_cell_forces=True
+    )
 
     results = torchsim_mace_mpa(ts_current_system_state)
     ts_initial_system_state = ts_current_system_state.clone()
@@ -138,6 +140,7 @@ def _run_and_compare_optimizers(
                 optimizer=optimizer_callable_for_ts_optimize,
                 max_steps=steps_for_current_segment,
                 convergence_fn=convergence_fn,
+                steps_between_swaps=1,
             )
             ts_current_system_state = updated_ts_state.clone()
 

--- a/tests/test_optimizers_vs_ase.py
+++ b/tests/test_optimizers_vs_ase.py
@@ -29,7 +29,7 @@ def _compare_ase_and_ts_states(
         scale=False,
     )
 
-    tkwargs = {
+    tensor_kwargs = {
         "device": ts_current_system_state.device,
         "dtype": ts_current_system_state.dtype,
     }
@@ -47,9 +47,10 @@ def _compare_ase_and_ts_states(
     final_ase_energy = final_ase_atoms.get_potential_energy()
     ase_forces_raw = final_ase_atoms.get_forces()
     final_ase_forces_max = torch.norm(
-        torch.tensor(ase_forces_raw, **tkwargs), dim=-1
+        torch.tensor(ase_forces_raw, **tensor_kwargs), dim=-1
     ).max()
-    ase_structure = state_to_structures(atoms_to_state(final_ase_atoms, **tkwargs))[0]
+    ts_state = atoms_to_state(final_ase_atoms, **tensor_kwargs)
+    ase_structure = state_to_structures(ts_state)[0]
 
     # Compare energies
     energy_diff = abs(final_custom_energy - final_ase_energy)
@@ -69,9 +70,8 @@ def _compare_ase_and_ts_states(
 
     # Compare structures using StructureMatcher
     assert structure_matcher.fit(ts_structure, ase_structure), (
-        f"{current_test_id}: Structures do not match according to StructureMatcher, "
-        f"{ts_structure=}"
-        f"{ase_structure=}"
+        f"{current_test_id}: Structures do not match according to StructureMatcher\n"
+        f"{ts_structure=}\n{ase_structure=}"
     )
 
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -297,7 +297,7 @@ def test_optimize_fire(
 
     # Check force convergence
     assert torch.all(final_state.forces < 3e-1)
-    assert energies.shape[0] > 10
+    assert energies.shape[0] >= 10
     assert energies[0] > energies[-1]
     assert not torch.allclose(original_state.positions, final_state.positions)
 
@@ -327,7 +327,8 @@ def test_default_converged_fn(
     with TorchSimTrajectory(traj_file) as traj:
         energies = traj.get_array("energy")
 
-    assert energies[-3] > energies[-1]
+    # Check that overall energy decreases (first to last)
+    assert energies[0] > energies[-1]
     assert not torch.allclose(original_state.positions, final_state.positions)
 
 

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -1030,7 +1030,9 @@ class InFlightAutoBatcher:
         # Increment attempt counters and check for max attempts in a single loop
         for cur_idx, abs_idx in enumerate(self.current_idx):
             self.swap_attempts[abs_idx] += 1
-            if self.max_attempts and (self.swap_attempts[abs_idx] >= self.max_attempts):
+            if self.max_attempts is not None and (
+                self.swap_attempts[abs_idx] >= self.max_attempts
+            ):
                 # Force convergence for states that have reached max attempts
                 convergence_tensor[cur_idx] = torch.tensor(True)  # noqa: FBT003
 

--- a/torch_sim/math.py
+++ b/torch_sim/math.py
@@ -993,7 +993,6 @@ def batched_vdot(
     x: torch.Tensor, y: torch.Tensor, batch_indices: torch.Tensor
 ) -> torch.Tensor:
     """Computes batched vdot (sum of element-wise product) for groups of vectors.
-    If is_sum_sq is True, computes sum of x_i * x_i (squared norm components).
 
     Args:
         x: Tensor of shape [N_total_entities, D] (e.g., forces, velocities).
@@ -1002,11 +1001,20 @@ def batched_vdot(
 
     Returns:
         Tensor: shape [n_batches] where each element is the sum(x_i * y_i)
-        (or sum(x_i * x_i) if is_sum_sq) for entities belonging to that batch,
+    for entities belonging to that batch,
         summed over all components D and all entities in the batch.
     """
-    if x.ndim != 2 or batch_indices.ndim != 1 or x.shape[0] != batch_indices.shape[0]:
+    if (
+        x.ndim != 2
+        or y.ndim != 2
+        or batch_indices.ndim != 1
+        or x.shape != y.shape
+        or x.shape[0] != batch_indices.shape[0]
+    ):
         raise ValueError(f"Invalid input shapes: {x.shape=}, {batch_indices.shape=}")
+
+    if batch_indices.min() < 0:
+        raise ValueError("batch_indices must be non-negative")
 
     output = torch.zeros(batch_indices.max() + 1, dtype=x.dtype, device=x.device)
     output.scatter_add_(dim=0, index=batch_indices, src=(x * y).sum(dim=1))

--- a/torch_sim/math.py
+++ b/torch_sim/math.py
@@ -997,7 +997,7 @@ def batched_vdot(
 
     Args:
         x: Tensor of shape [N_total_entities, D] (e.g., forces, velocities).
-        y: Tensor of shape [N_total_entities, D]. Ignored if is_sum_sq is True.
+        y: Tensor of shape [N_total_entities, D].
         batch_indices: Tensor of shape [N_total_entities] indicating batch membership.
 
     Returns:

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -1410,7 +1410,7 @@ VALID_FIRE_CELL_STATES = (UnitCellFireState, FrechetCellFIREState)
 
 
 def _ase_fire_step(  # noqa: C901, PLR0915
-    state: FireState | VALID_FIRE_CELL_STATES,
+    state: FireState | UnitCellFireState | FrechetCellFIREState,
     model: torch.nn.Module,
     *,
     dt_max: torch.Tensor,

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -338,6 +338,7 @@ def unit_cell_gradient_descent(  # noqa: PLR0915, C901
             forces=forces,
             energy=energy,
             stress=stress,
+            velocities=None,
             masses=state.masses,
             cell=state.cell,
             pbc=state.pbc,
@@ -476,6 +477,7 @@ class FireState(SimState):
     # Required attributes not in SimState
     forces: torch.Tensor
     energy: torch.Tensor
+    velocities: torch.Tensor | None
 
     # FIRE algorithm parameters
     dt: torch.Tensor
@@ -592,6 +594,7 @@ def fire(
             atomic_numbers=state.atomic_numbers.clone(),
             batch=state.batch.clone(),
             pbc=state.pbc,
+            velocities=None,
             forces=forces,
             energy=energy,
             # Optimization attributes
@@ -864,6 +867,7 @@ def unit_cell_fire(
             atomic_numbers=state.atomic_numbers.clone(),
             batch=state.batch.clone(),
             pbc=state.pbc,
+            velocities=None,
             forces=forces,
             energy=energy,
             stress=stress,
@@ -966,7 +970,7 @@ class FrechetCellFIREState(SimState, DeformGradMixin):
 
     # Cell attributes
     cell_positions: torch.Tensor
-    cell_velocities: torch.Tensor
+    cell_velocities: torch.Tensor | None
     cell_forces: torch.Tensor
     cell_masses: torch.Tensor
 
@@ -1162,6 +1166,7 @@ def frechet_cell_fire(
             atomic_numbers=state.atomic_numbers,
             batch=state.batch,
             pbc=state.pbc,
+            velocities=None,
             forces=forces,
             energy=energy,
             stress=stress,

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -1204,11 +1204,11 @@ def frechet_cell_fire(
     return fire_init, functools.partial(step_func, **step_func_kwargs)
 
 
-VALID_FIRE_CELL_STATES = UnitCellFireState | FrechetCellFIREState
+AnyFireCellState = UnitCellFireState | FrechetCellFIREState
 
 
 def _vv_fire_step(  # noqa: C901, PLR0915
-    state: FireState | VALID_FIRE_CELL_STATES,
+    state: FireState | AnyFireCellState,
     model: torch.nn.Module,
     *,
     dt_max: torch.Tensor,
@@ -1220,7 +1220,7 @@ def _vv_fire_step(  # noqa: C901, PLR0915
     eps: float,
     is_cell_optimization: bool = False,
     is_frechet: bool = False,
-) -> FireState | VALID_FIRE_CELL_STATES:
+) -> FireState | AnyFireCellState:
     """Perform one Velocity-Verlet based FIRE optimization step.
 
     Implements one step of the Fast Inertial Relaxation Engine (FIRE) algorithm for
@@ -1252,9 +1252,9 @@ def _vv_fire_step(  # noqa: C901, PLR0915
     if state.velocities is None:
         state.velocities = torch.zeros_like(state.positions)
         if is_cell_optimization:
-            if not isinstance(state, VALID_FIRE_CELL_STATES):
+            if not isinstance(state, AnyFireCellState):
                 raise ValueError(
-                    "Cell optimization requires one of {VALID_FIRE_CELL_STATES}."
+                    f"Cell optimization requires one of {get_args(AnyFireCellState)}."
                 )
             state.cell_velocities = torch.zeros(
                 (n_batches, 3, 3), device=device, dtype=dtype
@@ -1418,7 +1418,7 @@ def _vv_fire_step(  # noqa: C901, PLR0915
 
 
 def _ase_fire_step(  # noqa: C901, PLR0915
-    state: FireState | VALID_FIRE_CELL_STATES,
+    state: FireState | AnyFireCellState,
     model: torch.nn.Module,
     *,
     dt_max: torch.Tensor,
@@ -1431,7 +1431,7 @@ def _ase_fire_step(  # noqa: C901, PLR0915
     eps: float,
     is_cell_optimization: bool = False,
     is_frechet: bool = False,
-) -> FireState | VALID_FIRE_CELL_STATES:
+) -> FireState | AnyFireCellState:
     """Perform one ASE-style FIRE optimization step.
 
     Implements one step of the Fast Inertial Relaxation Engine (FIRE) algorithm
@@ -1462,9 +1462,9 @@ def _ase_fire_step(  # noqa: C901, PLR0915
         state.velocities = torch.zeros_like(state.positions)
         forces = state.forces
         if is_cell_optimization:
-            if not isinstance(state, VALID_FIRE_CELL_STATES):
+            if not isinstance(state, AnyFireCellState):
                 raise ValueError(
-                    "Cell optimization requires one of {VALID_FIRE_CELL_STATES}."
+                    f"Cell optimization requires one of {get_args(AnyFireCellState)}."
                 )
             state.cell_velocities = torch.zeros(
                 (n_batches, 3, 3), device=device, dtype=dtype

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -1504,7 +1504,7 @@ def _ase_fire_step(  # noqa: C901, PLR0915
         v_scaling_batch = tsm.batched_vdot(
             state.velocities, state.velocities, state.batch
         )
-        f_scaling_batch = tsm.batched_vdot(state.forces, state.forces, state.batch)
+        f_scaling_batch = tsm.batched_vdot(forces, forces, state.batch)
 
         if is_cell_optimization:
             v_scaling_batch += state.cell_velocities.pow(2).sum(dim=(1, 2))
@@ -1524,7 +1524,7 @@ def _ase_fire_step(  # noqa: C901, PLR0915
 
         v_scaling_atom = torch.sqrt(v_scaling_batch[state.batch].unsqueeze(-1))
         f_scaling_atom = torch.sqrt(f_scaling_batch[state.batch].unsqueeze(-1))
-        v_mixing_atom = state.forces * (v_scaling_atom / (f_scaling_atom + eps))
+        v_mixing_atom = forces * (v_scaling_atom / (f_scaling_atom + eps))
 
         alpha_atom = state.alpha[state.batch].unsqueeze(-1)  # per-atom alpha
         state.velocities = torch.where(
@@ -1534,7 +1534,7 @@ def _ase_fire_step(  # noqa: C901, PLR0915
         )
 
     # 4. Acceleration (single forward-Euler, no mass for ASE FIRE)
-    state.velocities += state.forces * state.dt[state.batch].unsqueeze(-1)
+    state.velocities += forces * state.dt[state.batch].unsqueeze(-1)
     dr_atom = state.velocities * state.dt[state.batch].unsqueeze(-1)
     dr_scaling_batch = tsm.batched_vdot(dr_atom, dr_atom, state.batch)
 

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -338,7 +338,6 @@ def unit_cell_gradient_descent(  # noqa: PLR0915, C901
             forces=forces,
             energy=energy,
             stress=stress,
-            velocities=None,
             masses=state.masses,
             cell=state.cell,
             pbc=state.pbc,
@@ -483,8 +482,6 @@ class FireState(SimState):
     dt: torch.Tensor
     alpha: torch.Tensor
     n_pos: torch.Tensor
-
-    velocities: torch.Tensor | None = None
 
 
 def fire(

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -866,13 +866,13 @@ def unit_cell_fire(
             batch=state.batch.clone(),
             pbc=state.pbc,
             # New attributes
-            velocities=torch.zeros_like(state.positions),
+            velocities=None,
             forces=forces,
             energy=energy,
             stress=stress,
             # Cell attributes
             cell_positions=torch.zeros(n_batches, 3, 3, device=device, dtype=dtype),
-            cell_velocities=torch.zeros(n_batches, 3, 3, device=device, dtype=dtype),
+            cell_velocities=None,
             cell_forces=cell_forces,
             cell_masses=cell_masses,
             # Optimization attributes
@@ -1585,10 +1585,10 @@ def _ase_fire_step(  # noqa: C901, PLR0915
             F_new_scaled = current_F_scaled + dr_cell
             state.cell_positions = F_new_scaled
             F_new = F_new_scaled / (cell_factor_exp_mult + eps)
-            new_cell_column_vectors = torch.bmm(
-                state.reference_cell, F_new.transpose(-2, -1)
+            new_row_vector_cell = torch.bmm(
+                state.reference_row_vector_cell, F_new.transpose(-2, -1)
             )
-            state.cell = new_cell_column_vectors
+            state.row_vector_cell = new_row_vector_cell
 
         state.positions = torch.bmm(
             state.positions.unsqueeze(1), F_new[state.batch].transpose(-2, -1)

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -592,7 +592,7 @@ def fire(
             batch=state.batch.clone(),
             pbc=state.pbc,
             # New attributes
-            velocities=torch.zeros_like(state.positions),
+            velocities=None,
             forces=forces,
             energy=energy,
             # Optimization attributes
@@ -1491,10 +1491,10 @@ def _ase_fire_step(  # noqa: C901, PLR0915
         pos_mask_batch = batch_power > 0.0
         neg_mask_batch = ~pos_mask_batch
 
-        state.n_pos[pos_mask_batch] += 1
         inc_mask = (state.n_pos > n_min) & pos_mask_batch
         state.dt[inc_mask] = torch.minimum(state.dt[inc_mask] * f_inc, dt_max)
         state.alpha[inc_mask] *= f_alpha
+        state.n_pos[pos_mask_batch] += 1
 
         state.dt[neg_mask_batch] *= f_dec
         state.alpha[neg_mask_batch] = alpha_start_batch[neg_mask_batch]

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -476,7 +476,7 @@ class FireState(SimState):
     # Required attributes not in SimState
     forces: torch.Tensor
     energy: torch.Tensor
-    velocities: torch.Tensor
+    velocities: torch.Tensor | None = None
 
     # FIRE algorithm parameters
     dt: torch.Tensor

--- a/torch_sim/optimizers.py
+++ b/torch_sim/optimizers.py
@@ -476,12 +476,13 @@ class FireState(SimState):
     # Required attributes not in SimState
     forces: torch.Tensor
     energy: torch.Tensor
-    velocities: torch.Tensor | None = None
 
     # FIRE algorithm parameters
     dt: torch.Tensor
     alpha: torch.Tensor
     n_pos: torch.Tensor
+
+    velocities: torch.Tensor | None = None
 
 
 def fire(
@@ -591,8 +592,6 @@ def fire(
             atomic_numbers=state.atomic_numbers.clone(),
             batch=state.batch.clone(),
             pbc=state.pbc,
-            # New attributes
-            velocities=None,
             forces=forces,
             energy=energy,
             # Optimization attributes
@@ -865,8 +864,6 @@ def unit_cell_fire(
             atomic_numbers=state.atomic_numbers.clone(),
             batch=state.batch.clone(),
             pbc=state.pbc,
-            # New attributes
-            velocities=None,
             forces=forces,
             energy=energy,
             stress=stress,
@@ -1165,8 +1162,6 @@ def frechet_cell_fire(
             atomic_numbers=state.atomic_numbers,
             batch=state.batch,
             pbc=state.pbc,
-            # New attributes
-            velocities=None,
             forces=forces,
             energy=energy,
             stress=stress,

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -278,12 +278,13 @@ def _chunked_apply(
     return concatenate_states(ordered_states)
 
 
-def generate_force_convergence_fn(force_tol: float = 1e-1) -> Callable:
+def generate_force_convergence_fn(force_tol: float = 1e-1, include_cell_forces: bool = False) -> Callable:
     """Generate a force-based convergence function for the convergence_fn argument
     of the optimize function.
 
     Args:
         force_tol (float): Force tolerance for convergence
+        include_cell_forces (bool): Whether to include the `cell_forces` in the convergence check.
 
     Returns:
         Convergence function that takes a state and last energy and
@@ -295,7 +296,14 @@ def generate_force_convergence_fn(force_tol: float = 1e-1) -> Callable:
         last_energy: torch.Tensor | None = None,  # noqa: ARG001
     ) -> bool:
         """Check if the system has converged."""
-        return batchwise_max_force(state) < force_tol
+        force_conv = batchwise_max_force(state) < force_tol
+        if not include_cell_forces:
+            return force_conv
+
+        cell_forces_norm, _ = state.cell_forces.norm(dim=2).max(dim=1)
+        cell_force_conv = cell_forces_norm < force_tol
+        
+        return force_conv & cell_force_conv
 
     return convergence_fn
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -537,8 +537,8 @@ def static(
         pbar_kwargs.setdefault("disable", None)
         tqdm_pbar = tqdm(total=state.n_batches, **pbar_kwargs)
 
-    for substate, batch_indices in batch_iterator:
-        print(substate.atomic_numbers)
+    for sub_state, batch_indices in batch_iterator:
+        print(sub_state.atomic_numbers)
         # set up trajectory reporters
         if autobatcher and trajectory_reporter and og_filenames is not None:
             # we must remake the trajectory reporter for each batch
@@ -546,20 +546,20 @@ def static(
                 filenames=[og_filenames[idx] for idx in batch_indices]
             )
 
-        model_outputs = model(substate)
+        model_outputs = model(sub_state)
 
-        substate = StaticState(
-            **vars(substate),
+        sub_state = StaticState(
+            **vars(sub_state),
             energy=model_outputs["energy"],
             forces=model_outputs["forces"] if model.compute_forces else None,
             stress=model_outputs["stress"] if model.compute_stress else None,
         )
 
-        props = trajectory_reporter.report(substate, 0, model=model)
+        props = trajectory_reporter.report(sub_state, 0, model=model)
         all_props.extend(props)
 
         if tqdm_pbar:
-            tqdm_pbar.update(substate.n_batches)
+            tqdm_pbar.update(sub_state.n_batches)
 
     trajectory_reporter.finish()
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -278,13 +278,16 @@ def _chunked_apply(
     return concatenate_states(ordered_states)
 
 
-def generate_force_convergence_fn(force_tol: float = 1e-1, include_cell_forces: bool = False) -> Callable:
+def generate_force_convergence_fn(
+    force_tol: float = 1e-1, *, include_cell_forces: bool = False
+) -> Callable:
     """Generate a force-based convergence function for the convergence_fn argument
     of the optimize function.
 
     Args:
         force_tol (float): Force tolerance for convergence
-        include_cell_forces (bool): Whether to include the `cell_forces` in the convergence check.
+        include_cell_forces (bool): Whether to include the `cell_forces` in
+            the convergence check.
 
     Returns:
         Convergence function that takes a state and last energy and
@@ -302,7 +305,7 @@ def generate_force_convergence_fn(force_tol: float = 1e-1, include_cell_forces: 
 
         cell_forces_norm, _ = state.cell_forces.norm(dim=2).max(dim=1)
         cell_force_conv = cell_forces_norm < force_tol
-        
+
         return force_conv & cell_force_conv
 
     return convergence_fn


### PR DESCRIPTION
It seems that the remaining deviations could be fixed. This branch is already based on the changes in #201, I'll do the rebase once it is merged.

* I reduced the number of "inner" updates in the testing script to `1`, in order to get the precise number of convergence steps
* In the pos-only case, two small fixes were necessary that led to a wrong (or better to say different) `dt`
* The Frechet Cell optimization also required some additional changes, i.e., correctly scaling the positions with respect to the deformation gradient. See https://gitlab.com/ase/ase/-/blob/master/ase/filters.py?ref_type=heads#L440-441 and https://gitlab.com/ase/ase/-/blob/master/ase/filters.py?ref_type=heads#L405-406
* The previously (#199) introduced rescaling of the positions with respect to the new cell was not necessary (it seems that those were anyway overwritten in ASE: https://gitlab.com/ase/ase/-/blob/master/ase/filters.py?ref_type=heads#L434-441), so I removed it again
* Finally, I adapted the `generate_force_convergence_fn` function to optionally also include the `cell_forces` in the convergence check, which is done in `ASE` and therefore caused the differing numbers of convergence steps

![fig1](https://github.com/user-attachments/assets/b1610ff3-4f40-4d7e-824b-70728f1ef3ae)

![fig2](https://github.com/user-attachments/assets/926d871e-11d9-43c4-85a1-ece08b5d173f)

![fig3](https://github.com/user-attachments/assets/8427b889-8f6a-4648-a716-8ab1e80dec70)


