### PR TITLE
Fix memory scaling in `determine_max_batch_size`

### DIFF
--- a/docs/_static/draw_pkg_treemap.py
+++ b/docs/_static/draw_pkg_treemap.py
@@ -6,6 +6,7 @@ Run with `uv run docs/_static/draw_pkg_treemap.py`
 # /// script
 # dependencies = [
 #     "pymatviz @ git+https://github.com/janosh/pymatviz",
+#     "plotly!=6.2.0", # TODO remove pin pending https://github.com/plotly/plotly.py/issues/5253#issuecomment-3016615635
 # ]
 # ///
 

--- a/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
+++ b/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
@@ -4,7 +4,7 @@
 # dependencies = [
 #     "mace-torch>=0.3.12",
 #     "phonopy>=2.35",
-#     "pymatviz[export-figs]>=0.15.1",
+#     "pymatviz>=0.15.1",
 #     "seekpath",
 #     "ase",
 # ]

--- a/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
+++ b/examples/scripts/6_Phonons/6.1_Phonons_MACE.py
@@ -4,9 +4,10 @@
 # dependencies = [
 #     "mace-torch>=0.3.12",
 #     "phonopy>=2.35",
-#     "pymatviz>=0.15.1",
+#     "pymatviz>=0.16",
 #     "seekpath",
 #     "ase",
+#     "plotly!=6.2.0", # TODO remove pin pending https://github.com/plotly/plotly.py/issues/5253#issuecomment-3016615635
 # ]
 # ///
 

--- a/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
+++ b/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
@@ -6,7 +6,8 @@ different volumes and FC2 calculations with MACE.
 # dependencies = [
 #     "mace-torch>=0.3.12",
 #     "phonopy>=2.35",
-#     "pymatviz>=0.15.1",
+#     "pymatviz>=0.16",
+#     "plotly!=6.2.0", # TODO remove pin pending https://github.com/plotly/plotly.py/issues/5253#issuecomment-3016615635
 # ]
 # ///
 

--- a/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
+++ b/examples/scripts/6_Phonons/6.2_QuasiHarmonic_MACE.py
@@ -6,7 +6,7 @@ different volumes and FC2 calculations with MACE.
 # dependencies = [
 #     "mace-torch>=0.3.12",
 #     "phonopy>=2.35",
-#     "pymatviz[export-figs]>=0.15.1",
+#     "pymatviz>=0.15.1",
 # ]
 # ///
 

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -268,7 +268,7 @@ def determine_max_batch_size(
             Defaults to 500,000.
         start_size (int): Initial batch size to test. Defaults to 1.
         scale_factor (float): Factor to multiply batch size by in each iteration.
-            Defaults to 1.3.
+            Defaults to 1.6.
 
     Returns:
         int: Maximum number of batches that fit in GPU memory.
@@ -289,7 +289,7 @@ def determine_max_batch_size(
     """
     # Create a geometric sequence of batch sizes
     sizes = [start_size]
-    while (next_size := round(sizes[-1] * scale_factor)) < max_atoms:
+    while (next_size := max(round(sizes[-1] * scale_factor), sizes[-1] + 1)) < max_atoms:
         sizes.append(next_size)
 
     for i in range(len(sizes)):


### PR DESCRIPTION
The current version results in an infinite loop when `scale_factor < 1.5` due to the rounding. 

This is fixed by increasing the batch size by at least `+1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved batch size scaling logic to ensure consistent increases and prevent potential infinite loops or stagnation.
  * Updated the default scaling factor for batch size determination to provide more efficient batch size progression.
* **Bug Fixes**
  * Added tests to verify batch size calculation avoids infinite loops with small scaling factors.
* **Chores**
  * Updated dependency specifications by removing optional features from package declarations in example scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->