### PR TITLE
Rename batch to system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage.xml
 
 # env
 uv.lock
+
+# IDE
+.vscode/

--- a/examples/scripts/1_Introduction/1.2_MACE.py
+++ b/examples/scripts/1_Introduction/1.2_MACE.py
@@ -63,19 +63,19 @@ positions = torch.tensor(positions_numpy, device=device, dtype=dtype)
 cell = torch.tensor(cell_numpy, device=device, dtype=dtype)
 atomic_numbers = torch.tensor(atomic_numbers_numpy, device=device, dtype=torch.int)
 
-# create batch index array of shape (16,) which is 0 for first 8 atoms, 1 for last 8 atoms
-atoms_per_batch = torch.tensor(
+# create system idx array of shape (16,) which is 0 for first 8 atoms, 1 for last 8 atoms
+atoms_per_system = torch.tensor(
     [len(atoms) for atoms in atoms_list], device=device, dtype=torch.int
 )
-batch = torch.repeat_interleave(
-    torch.arange(len(atoms_per_batch), device=device), atoms_per_batch
+system_idx = torch.repeat_interleave(
+    torch.arange(len(atoms_per_system), device=device), atoms_per_system
 )
 
 # You can see their shapes are as expected
 print(f"Positions: {positions.shape}")
 print(f"Cell: {cell.shape}")
 print(f"Atomic numbers: {atomic_numbers.shape}")
-print(f"Batch: {batch.shape}")
+print(f"System indices: {system_idx.shape}")
 
 # Now we can pass them to the model
 results = batched_model(
@@ -83,18 +83,18 @@ results = batched_model(
         positions=positions,
         cell=cell,
         atomic_numbers=atomic_numbers,
-        batch=batch,
+        system_idx=system_idx,
         pbc=True,
     )
 )
 
-# The energy has shape (n_batches,) as the structures in a batch
+# The energy has shape (n_systems,) as the structures in a batch
 print(f"Energy: {results['energy'].shape}")
 
 # The forces have shape (n_atoms, 3) same as positions
 print(f"Forces: {results['forces'].shape}")
 
-# The stress has shape (n_batches, 3, 3) same as cell
+# The stress has shape (n_systems, 3, 3) same as cell
 print(f"Stress: {results['stress'].shape}")
 
 # Check if the energy, forces, and stress are the same for the Si system across the batch

--- a/examples/scripts/2_Structural_optimization/2.3_MACE_Gradient_Descent.py
+++ b/examples/scripts/2_Structural_optimization/2.3_MACE_Gradient_Descent.py
@@ -93,12 +93,12 @@ atomic_numbers = torch.tensor(atomic_numbers_numpy, device=device, dtype=torch.i
 masses_numpy = np.concatenate([atoms.get_masses() for atoms in atoms_list])
 masses = torch.tensor(masses_numpy, device=device, dtype=dtype)
 
-# Create batch indices tensor for scatter operations
-atoms_per_batch = torch.tensor(
+# Create system indices tensor for scatter operations
+atoms_per_system = torch.tensor(
     [len(atoms) for atoms in atoms_list], device=device, dtype=torch.int
 )
-batch_indices = torch.repeat_interleave(
-    torch.arange(len(atoms_per_batch), device=device), atoms_per_batch
+system_indices = torch.repeat_interleave(
+    torch.arange(len(atoms_per_system), device=device), atoms_per_system
 )
 """
 
@@ -106,7 +106,7 @@ state = ts.io.atoms_to_state(atoms_list, device=device, dtype=dtype)
 
 print(f"Positions shape: {state.positions.shape}")
 print(f"Cell shape: {state.cell.shape}")
-print(f"Batch indices shape: {state.batch.shape}")
+print(f"System indices shape: {state.system_idx.shape}")
 
 # Run initial inference
 results = batched_model(state)

--- a/examples/scripts/2_Structural_optimization/2.5_MACE_UnitCellFilter_Gradient_Descent.py
+++ b/examples/scripts/2_Structural_optimization/2.5_MACE_UnitCellFilter_Gradient_Descent.py
@@ -85,7 +85,7 @@ cell_lr = 0.1
 # Initialize unit cell gradient descent optimizer
 gd_init, gd_update = unit_cell_gradient_descent(
     model=model,
-    cell_factor=None,  # Will default to atoms per batch
+    cell_factor=None,  # Will default to atoms per system
     hydrostatic_strain=False,
     constant_volume=False,
     scalar_pressure=0.0,

--- a/examples/scripts/2_Structural_optimization/2.6_MACE_UnitCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.6_MACE_UnitCellFilter_FIRE.py
@@ -81,7 +81,7 @@ results = model(state)
 # Initialize unit cell gradient descent optimizer
 fire_init, fire_update = unit_cell_fire(
     model=model,
-    cell_factor=None,  # Will default to atoms per batch
+    cell_factor=None,  # Will default to atoms per system
     hydrostatic_strain=False,
     constant_volume=False,
     scalar_pressure=0.0,

--- a/examples/scripts/2_Structural_optimization/2.7_MACE_FrechetCellFilter_FIRE.py
+++ b/examples/scripts/2_Structural_optimization/2.7_MACE_FrechetCellFilter_FIRE.py
@@ -80,7 +80,7 @@ results = model(state)
 # Initialize unit cell gradient descent optimizer
 fire_init, fire_update = ts.optimizers.frechet_cell_fire(
     model=model,
-    cell_factor=None,  # Will default to atoms per batch
+    cell_factor=None,  # Will default to atoms per system
     hydrostatic_strain=False,
     constant_volume=False,
     scalar_pressure=0.0,

--- a/examples/scripts/3_Dynamics/3.10_Hybrid_swap_mc.py
+++ b/examples/scripts/3_Dynamics/3.10_Hybrid_swap_mc.py
@@ -86,7 +86,7 @@ swap_state = swap_init(md_state)
 hybrid_state = HybridSwapMCState(
     **vars(md_state),
     last_permutation=torch.zeros(
-        md_state.n_batches, device=md_state.device, dtype=torch.bool
+        md_state.n_systems, device=md_state.device, dtype=torch.bool
     ),
 )
 

--- a/examples/scripts/3_Dynamics/3.11_Lennard_Jones_NPT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.11_Lennard_Jones_NPT_Langevin.py
@@ -119,13 +119,15 @@ state = npt_init(state=state, seed=1)
 for step in range(N_steps):
     if step % 50 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         pressure = get_pressure(
             model(state)["stress"],
             calc_kinetic_energy(
-                masses=state.masses, momenta=state.momenta, batch=state.batch
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
             ),
             torch.linalg.det(state.cell),
         )
@@ -139,7 +141,7 @@ for step in range(N_steps):
     state = npt_update(state, kT=kT, external_pressure=target_pressure)
 
 temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {temp.item():.4f}")
@@ -147,7 +149,7 @@ print(f"Final temperature: {temp.item():.4f}")
 
 stress = model(state)["stress"]
 calc_kinetic_energy = calc_kinetic_energy(
-    masses=state.masses, momenta=state.momenta, batch=state.batch
+    masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
 )
 volume = torch.linalg.det(state.cell)
 pressure = get_pressure(stress, calc_kinetic_energy, volume)

--- a/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.12_MACE_NPT_Langevin.py
@@ -68,7 +68,9 @@ state = nvt_init(state=state, seed=1)
 for step in range(N_steps_nvt):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         invariant = float(nvt_nose_hoover_invariant(state, kT=kT))
@@ -83,7 +85,9 @@ state = npt_init(state=state, seed=1)
 for step in range(N_steps_npt):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         stress = model(state)["stress"]
@@ -92,7 +96,9 @@ for step in range(N_steps_npt):
             get_pressure(
                 stress,
                 calc_kinetic_energy(
-                    masses=state.masses, momenta=state.momenta, batch=state.batch
+                    masses=state.masses,
+                    momenta=state.momenta,
+                    system_idx=state.system_idx,
                 ),
                 volume,
             ).item()
@@ -107,7 +113,7 @@ for step in range(N_steps_npt):
     state = npt_update(state, kT=kT, external_pressure=target_pressure)
 
 final_temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {final_temp.item():.4f} K")
@@ -117,7 +123,7 @@ final_pressure = (
     get_pressure(
         final_stress,
         calc_kinetic_energy(
-            masses=state.masses, momenta=state.momenta, batch=state.batch
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         ),
         final_volume,
     ).item()

--- a/examples/scripts/3_Dynamics/3.13_MACE_NVE_non_pbc.py
+++ b/examples/scripts/3_Dynamics/3.13_MACE_NVE_non_pbc.py
@@ -77,7 +77,7 @@ print("\nStarting NVE molecular dynamics simulation...")
 start_time = time.perf_counter()
 for step in range(N_steps):
     total_energy = state.energy + calc_kinetic_energy(
-        masses=state.masses, momenta=state.momenta, batch=state.batch
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
     if step % 10 == 0:
         print(f"Step {step}: Total energy: {total_energy.item():.4f} eV")

--- a/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
+++ b/examples/scripts/3_Dynamics/3.2_MACE_NVE.py
@@ -88,7 +88,7 @@ print("\nStarting NVE molecular dynamics simulation...")
 start_time = time.perf_counter()
 for step in range(N_steps):
     total_energy = state.energy + calc_kinetic_energy(
-        masses=state.masses, momenta=state.momenta, batch=state.batch
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
     if step % 10 == 0:
         print(f"Step {step}: Total energy: {total_energy.item():.4f} eV")

--- a/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
+++ b/examples/scripts/3_Dynamics/3.3_MACE_NVE_cueq.py
@@ -71,7 +71,7 @@ print("\nStarting NVE molecular dynamics simulation...")
 start_time = time.perf_counter()
 for step in range(N_steps):
     total_energy = state.energy + calc_kinetic_energy(
-        masses=state.masses, momenta=state.momenta, batch=state.batch
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
     if step % 10 == 0:
         print(f"Step {step}: Total energy: {total_energy.item():.4f} eV")

--- a/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
+++ b/examples/scripts/3_Dynamics/3.4_MACE_NVT_Langevin.py
@@ -83,14 +83,16 @@ state = langevin_init(state=state, seed=1)
 for step in range(N_steps):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         print(f"{step=}: Temperature: {temp.item():.4f}")
     state = langevin_update(state=state, kT=kT)
 
 final_temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {final_temp.item():.4f}")

--- a/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.5_MACE_NVT_Nose_Hoover.py
@@ -68,7 +68,9 @@ state = nvt_init(state=state, kT=kT, seed=1)
 for step in range(N_steps):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         invariant = float(nvt_nose_hoover_invariant(state, kT=kT))
@@ -76,7 +78,7 @@ for step in range(N_steps):
     state = nvt_update(state=state, kT=kT)
 
 final_temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {final_temp.item():.4f}")

--- a/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
+++ b/examples/scripts/3_Dynamics/3.6_MACE_NVT_Nose_Hoover_temp_profile.py
@@ -163,7 +163,7 @@ for step in range(n_steps):
 
     # Calculate current temperature and save data
     temp = (
-        calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+        calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
         / Units.temperature
     )
     actual_temps[step] = temp

--- a/examples/scripts/3_Dynamics/3.7_Lennard_Jones_NPT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.7_Lennard_Jones_NPT_Nose_Hoover.py
@@ -123,14 +123,16 @@ state = npt_init(state=state, seed=1)
 for step in range(N_steps):
     if step % 50 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         invariant = float(
             npt_nose_hoover_invariant(state, kT=kT, external_pressure=target_pressure)
         )
         e_kin = calc_kinetic_energy(
-            masses=state.masses, momenta=state.momenta, batch=state.batch
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         pressure = get_pressure(
             model(state)["stress"], e_kin, torch.det(state.current_cell)
@@ -145,14 +147,16 @@ for step in range(N_steps):
     state = npt_update(state, kT=kT, external_pressure=target_pressure)
 
 temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {temp.item():.4f}")
 
 pressure = get_pressure(
     model(state)["stress"],
-    calc_kinetic_energy(masses=state.masses, momenta=state.momenta, batch=state.batch),
+    calc_kinetic_energy(
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+    ),
     torch.det(state.current_cell),
 )
 pressure = pressure.item() / Units.pressure

--- a/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
+++ b/examples/scripts/3_Dynamics/3.8_MACE_NPT_Nose_Hoover.py
@@ -69,7 +69,9 @@ state = npt_init(state=state, seed=1)
 for step in range(N_steps_nvt):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         invariant = float(
@@ -86,7 +88,9 @@ state = npt_init(state=state, seed=1)
 for step in range(N_steps_npt):
     if step % 10 == 0:
         temp = (
-            calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+            calc_kT(
+                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+            )
             / Units.temperature
         )
         invariant = float(
@@ -95,7 +99,7 @@ for step in range(N_steps_npt):
         stress = model(state)["stress"]
         volume = torch.det(state.current_cell)
         e_kin = calc_kinetic_energy(
-            masses=state.masses, momenta=state.momenta, batch=state.batch
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         pressure = float(get_pressure(stress, e_kin, volume))
         xx, yy, zz = torch.diag(state.current_cell[0])
@@ -107,7 +111,7 @@ for step in range(N_steps_npt):
     state = npt_update(state, kT=kT, external_pressure=target_pressure)
 
 final_temp = (
-    calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+    calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
     / Units.temperature
 )
 print(f"Final temperature: {final_temp.item():.4f}")
@@ -115,7 +119,9 @@ final_stress = model(state)["stress"]
 final_volume = torch.det(state.current_cell)
 final_pressure = get_pressure(
     final_stress,
-    calc_kinetic_energy(masses=state.masses, momenta=state.momenta, batch=state.batch),
+    calc_kinetic_energy(
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+    ),
     final_volume,
 )
 print(f"Final pressure: {final_pressure.item():.4f}")

--- a/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
+++ b/examples/scripts/3_Dynamics/3.9_MACE_NVT_staggered_stress.py
@@ -65,7 +65,7 @@ state = nvt_init(state, kT=kT, seed=1)
 stress = torch.zeros(N_steps // 10, 3, 3, device=device, dtype=dtype)
 for step in range(N_steps):
     temp = (
-        calc_kT(masses=state.masses, momenta=state.momenta, batch=state.batch)
+        calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
         / Units.temperature
     )
 

--- a/examples/scripts/4_High_level_api/4.2_auto_batching_api.py
+++ b/examples/scripts/4_High_level_api/4.2_auto_batching_api.py
@@ -76,7 +76,7 @@ batcher.load_states(fire_states)
 all_completed_states, convergence_tensor, state = [], None, None
 while (result := batcher.next_batch(state, convergence_tensor))[0] is not None:
     state, completed_states = result
-    print(f"Starting new batch of {state.n_batches} states.")
+    print(f"Starting new batch of {state.n_systems} states.")
 
     all_completed_states.extend(completed_states)
     print("Total number of completed states", len(all_completed_states))

--- a/examples/scripts/5_Workflow/5.2_In_Flight_WBM.py
+++ b/examples/scripts/5_Workflow/5.2_In_Flight_WBM.py
@@ -83,7 +83,7 @@ batcher.load_states(fire_states)
 all_completed_states, convergence_tensor, state = [], None, None
 while (result := batcher.next_batch(state, convergence_tensor))[0] is not None:
     state, completed_states = result
-    print(f"Starting new batch of {state.n_batches} states.")
+    print(f"Starting new batch of {state.n_systems} states.")
 
     all_completed_states.extend(completed_states)
     print("Total number of completed states", len(all_completed_states))

--- a/examples/scripts/7_Others/7.3_Batched_neighbor_list.py
+++ b/examples/scripts/7_Others/7.3_Batched_neighbor_list.py
@@ -18,15 +18,15 @@ from torch_sim.neighbors import torch_nl_linked_cell, torch_nl_n2
 atoms_list = [bulk("Si", "diamond", a=5.43), bulk("Ge", "diamond", a=5.65)]
 state = ts.io.atoms_to_state(atoms_list, device="cpu", dtype=torch.float32)
 pos, cell, pbc = state.positions, state.cell, state.pbc
-batch, n_atoms = state.batch, state.n_atoms
+system_idx, n_atoms = state.system_idx, state.n_atoms
 cutoff = 4.0
 self_interaction = False
 
-# Fix: Ensure pbc has the correct shape [n_batches, 3]
+# Fix: Ensure pbc has the correct shape [n_systems, 3]
 pbc_tensor = torch.tensor([[pbc] * 3] * len(atoms_list), dtype=torch.bool)
 
 mapping, mapping_batch, shifts_idx = torch_nl_linked_cell(
-    cutoff, pos, cell, pbc_tensor, batch, self_interaction
+    cutoff, pos, cell, pbc_tensor, system_idx, self_interaction
 )
 cell_shifts = transforms.compute_cell_shifts(cell, shifts_idx, mapping_batch)
 dds = transforms.compute_distances_with_cell_shifts(pos, mapping, cell_shifts)
@@ -38,7 +38,7 @@ print(cell_shifts.shape)
 print(dds.shape)
 
 mapping_n2, mapping_batch_n2, shifts_idx_n2 = torch_nl_n2(
-    cutoff, pos, cell, pbc_tensor, batch, self_interaction
+    cutoff, pos, cell, pbc_tensor, system_idx, self_interaction
 )
 cell_shifts_n2 = transforms.compute_cell_shifts(cell, shifts_idx_n2, mapping_batch_n2)
 dds_n2 = transforms.compute_distances_with_cell_shifts(pos, mapping_n2, cell_shifts_n2)

--- a/examples/tutorials/autobatching_tutorial.py
+++ b/examples/tutorials/autobatching_tutorial.py
@@ -249,7 +249,7 @@ batcher.load_states(fire_state)
 fire_state.positions = (
     fire_state.positions + torch.randn_like(fire_state.positions) * 0.05
 )
-total_states = fire_state.n_batches
+total_states = fire_state.n_systems
 
 # Define a convergence function that checks the force on each atom is less than 5e-1
 convergence_fn = ts.generate_force_convergence_fn(5e-1)
@@ -279,11 +279,11 @@ final_states = batcher.restore_original_order(all_converged_states)
 assert len(final_states) == total_states
 
 # Note that the fire_state has been modified in place
-assert fire_state.n_batches == 0
+assert fire_state.n_systems == 0
 
 
 # %%
-fire_state.n_batches
+fire_state.n_systems
 
 
 # %% [markdown]

--- a/examples/tutorials/high_level_tutorial.py
+++ b/examples/tutorials/high_level_tutorial.py
@@ -375,7 +375,7 @@ The `optimize` function allows us to specify custom convergence criteria. The in
 convergence function are `state` and `last_energy`. The `state` is a `SimState` object
 that contains the current state of the system and the `last_energy` is the energy of the
 previous step. The convergence function should return a boolean tensor of length
-`n_batches`.
+`n_systems`.
 
 This is how we'd manually define the default `convergence_fn`:
 """

--- a/examples/tutorials/hybrid_swap_tutorial.py
+++ b/examples/tutorials/hybrid_swap_tutorial.py
@@ -133,7 +133,7 @@ swap_state = swap_init(md_state)
 hybrid_state = HybridSwapMCState(
     **vars(md_state),
     last_permutation=torch.zeros(
-        md_state.n_batches, device=md_state.device, dtype=torch.bool
+        md_state.n_systems, device=md_state.device, dtype=torch.bool
     ),
 )
 

--- a/examples/tutorials/low_level_tutorial.py
+++ b/examples/tutorials/low_level_tutorial.py
@@ -228,7 +228,7 @@ for step in range(30):
     state = nvt_langevin_update_fn(state=state, kT=initial_kT * (1 + step / 30))
     if step % 5 == 0:
         temp_E_units = ts.calc_kT(
-            masses=state.masses, momenta=state.momenta, batch=state.batch
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         temp = temp_E_units / MetalUnits.temperature
         print(f"{step=}: Temperature: {temp}")

--- a/examples/tutorials/state_tutorial.py
+++ b/examples/tutorials/state_tutorial.py
@@ -31,7 +31,7 @@ an atomistic system:
 * Unit cell parameters
 * Periodic boundary conditions
 * Atomic numbers (elements)
-* Batch indices (for processing multiple systems simultaneously)
+* System indices (for processing multiple systems simultaneously)
 
 """
 
@@ -58,7 +58,7 @@ si_atoms = bulk("Si", "diamond", a=5.43, cubic=True)
 # Convert to SimState
 si_state = ts.initialize_state(si_atoms, device=torch.device("cpu"), dtype=torch.float64)
 
-print(f"State has {si_state.n_atoms} atoms and {si_state.n_batches} batches")
+print(f"State has {si_state.n_atoms} atoms and {si_state.n_systems} systems")
 
 # here we print all the attributes of the SimState
 print(f"Positions shape: {si_state.positions.shape}")
@@ -66,7 +66,7 @@ print(f"Cell shape: {si_state.cell.shape}")
 print(f"Atomic numbers shape: {si_state.atomic_numbers.shape}")
 print(f"Masses shape: {si_state.masses.shape}")
 print(f"PBC: {si_state.pbc}")
-print(f"Batch indices shape: {si_state.batch.shape}")
+print(f"System indices shape: {si_state.system_idx.shape}")
 
 
 # %% [markdown]
@@ -75,7 +75,7 @@ SimState attributes fall into three categories: atomwise, batchwise, and global.
 
 * Atomwise attributes are tensors with shape (n_atoms, ...), these are `positions`,
   `masses`, `atomic_numbers`, and `batch`. Names are plural.
-* Batchwise attributes are tensors with shape (n_batches, ...), this is just `cell` for
+* Batchwise attributes are tensors with shape (n_systems, ...), this is just `cell` for
   the base SimState. Names are singular.
 * Global attributes have any other shape or type, just `pbc` here. Names are singular.
 
@@ -109,14 +109,14 @@ multi_state = ts.initialize_state(
 )
 
 print(
-    f"Multi-state has {multi_state.n_atoms} total atoms across {multi_state.n_batches} batches"
+    f"Multi-state has {multi_state.n_atoms} total atoms across {multi_state.n_systems} systems"
 )
 
 # we can see how the shapes of batchwise, atomwise, and global properties change
 print(f"Positions shape: {multi_state.positions.shape}")
 print(f"Cell shape: {multi_state.cell.shape}")
 print(f"PBC: {multi_state.pbc}")
-print(f"Batch indices shape: {multi_state.batch.shape}")
+print(f"System indices shape: {multi_state.system_idx.shape}")
 
 
 # %% [markdown]
@@ -148,18 +148,18 @@ containing only the first three batches. The other operations are available thro
 
 # %% we can copy the state with the clone method
 multi_state_copy = multi_state.clone()
-print(f"This state has {multi_state_copy.n_batches} batches")
+print(f"This state has {multi_state_copy.n_systems} systems")
 
 # we can pop states off while modifying the original state
 popped_states = multi_state_copy.pop([0, 2])
 print(
     f"We popped {len(popped_states)} states, leaving us with "
-    f"{multi_state_copy.n_batches} batch in the original state"
+    f"{multi_state_copy.n_systems} systems in the original state"
 )
 
 # we can put them back together with concatenate
 multi_state_full = ts.concatenate_states([*popped_states, multi_state_copy])
-print(f"Again we have {multi_state_full.n_batches} batches in the full state")
+print(f"Again we have {multi_state_full.n_systems} systems in the full state")
 
 # or if we don't want to modify the original state, we can instead index into it
 # negative indexing
@@ -253,14 +253,14 @@ md_state = MDState(
     **asdict(si_state),  # Copy all SimState properties
     momenta=torch.zeros_like(si_state.positions),  # Initial 0 momenta
     forces=torch.zeros_like(si_state.positions),  # Initial 0 forces
-    energy=torch.zeros((si_state.n_batches,), device=si_state.device),  # Initial 0 energy
+    energy=torch.zeros((si_state.n_systems,), device=si_state.device),  # Initial 0 energy
 )
 
 print("MDState properties:")
 scope = infer_property_scope(md_state)
 print("Global properties:", scope["global"])
 print("Per-atom properties:", scope["per_atom"])
-print("Per-batch properties:", scope["per_batch"])
+print("Per-system properties:", scope["per_system"])
 
 
 # %% [markdown]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_sim_atomistic"
-version = "0.2.2"
+version = "0.3.0"
 description = "A pytorch toolkit for calculating material properties using MLIPs"
 authors = [
     { name = "Abhijeet Gangan", email = "abhijeetgangan@g.ucla.edu" },

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -169,7 +169,7 @@ def make_validate_model_outputs_test(
 
         og_positions = sim_state.positions.clone()
         og_cell = sim_state.cell.clone()
-        og_batch = sim_state.batch.clone()
+        og_batch = sim_state.system_idx.clone()
         og_atomic_numbers = sim_state.atomic_numbers.clone()
 
         model_output = model.forward(sim_state)
@@ -177,7 +177,7 @@ def make_validate_model_outputs_test(
         # assert model did not mutate the input
         assert torch.allclose(og_positions, sim_state.positions)
         assert torch.allclose(og_cell, sim_state.cell)
-        assert torch.allclose(og_batch, sim_state.batch)
+        assert torch.allclose(og_batch, sim_state.system_idx)
         assert torch.allclose(og_atomic_numbers, sim_state.atomic_numbers)
 
         # assert model output has the correct keys

--- a/tests/test_correlations.py
+++ b/tests/test_correlations.py
@@ -31,12 +31,14 @@ class MockState:
         self.velocities = velocities
         self.device = device
         # Required for TrajectoryReporter
-        self.n_batches = 1
-        self.batch = torch.zeros(velocities.shape[0], device=device, dtype=torch.int64)
+        self.n_systems = 1
+        self.system_idx = torch.zeros(
+            velocities.shape[0], device=device, dtype=torch.int64
+        )
 
     def split(self) -> list["MockState"]:
-        """Split state into batches."""
-        # Just return self since 1 batch
+        """Split state into multiple systems."""
+        # Just return self since 1 system
         return [self]
 
 

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -109,7 +109,7 @@ def test_npt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
         state = update_fn(state=state)
 
         # Calculate instantaneous temperature from kinetic energy
-        temp = calc_kT(state.momenta, state.masses, batch=state.batch)
+        temp = calc_kT(state.momenta, state.masses, system_idx=state.system_idx)
         energies.append(state.energy)
         temperatures.append(temp / MetalUnits.temperature)
 
@@ -172,7 +172,7 @@ def test_npt_langevin_multi_kt(
         state = update_fn(state=state)
 
         # Calculate instantaneous temperature from kinetic energy
-        temp = calc_kT(state.momenta, state.masses, batch=state.batch)
+        temp = calc_kT(state.momenta, state.masses, system_idx=state.system_idx)
         energies.append(state.energy)
         temperatures.append(temp / MetalUnits.temperature)
 
@@ -213,7 +213,7 @@ def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
         state = update_fn(state=state)
 
         # Calculate instantaneous temperature from kinetic energy
-        temp = calc_kT(state.momenta, state.masses, batch=state.batch)
+        temp = calc_kT(state.momenta, state.masses, system_idx=state.system_idx)
         energies.append(state.energy)
         temperatures.append(temp / MetalUnits.temperature)
 
@@ -273,7 +273,7 @@ def test_nvt_langevin_multi_kt(
         state = update_fn(state=state)
 
         # Calculate instantaneous temperature from kinetic energy
-        temp = calc_kT(state.momenta, state.masses, batch=state.batch)
+        temp = calc_kT(state.momenta, state.masses, system_idx=state.system_idx)
         energies.append(state.energy)
         temperatures.append(temp / MetalUnits.temperature)
 
@@ -372,8 +372,8 @@ def test_compare_single_vs_batched_integrators(
         torch.testing.assert_close(single_state.energy, final_state.energy)
 
 
-def test_compute_cell_force_atoms_per_batch():
-    """Test that compute_cell_force correctly scales by number of atoms per batch.
+def test_compute_cell_force_atoms_per_system():
+    """Test that compute_cell_force correctly scales by number of atoms per system.
 
     Covers fix in https://github.com/Radical-AI/torch-sim/pull/153."""
     from torch_sim.integrators.npt import _compute_cell_force
@@ -389,7 +389,7 @@ def test_compute_cell_force_atoms_per_batch():
         masses=torch.ones(72),
         cell=torch.eye(3).repeat(2, 1, 1),
         pbc=True,
-        batch=torch.cat([s1, s2]),
+        system_idx=torch.cat([s1, s2]),
         atomic_numbers=torch.ones(72, dtype=torch.long),
         stress=torch.zeros((2, 3, 3)),
         reference_cell=torch.eye(3).repeat(2, 1, 1),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -48,9 +48,10 @@ def test_multiple_structures_to_state(
     assert state.cell.shape == (2, 3, 3)
     assert state.pbc
     assert state.atomic_numbers.shape == (16,)
-    assert state.batch.shape == (16,)
+    assert state.system_idx.shape == (16,)
     assert torch.all(
-        state.batch == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8)
+        state.system_idx
+        == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8)
     )
 
 
@@ -65,8 +66,8 @@ def test_single_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
     assert state.cell.shape == (1, 3, 3)
     assert state.pbc
     assert state.atomic_numbers.shape == (8,)
-    assert state.batch.shape == (8,)
-    assert torch.all(state.batch == 0)
+    assert state.system_idx.shape == (8,)
+    assert torch.all(state.system_idx == 0)
 
 
 def test_multiple_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
@@ -80,9 +81,10 @@ def test_multiple_atoms_to_state(si_atoms: Atoms, device: torch.device) -> None:
     assert state.cell.shape == (2, 3, 3)
     assert state.pbc
     assert state.atomic_numbers.shape == (16,)
-    assert state.batch.shape == (16,)
+    assert state.system_idx.shape == (16,)
     assert torch.all(
-        state.batch == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8),
+        state.system_idx
+        == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8),
     )
 
 
@@ -171,9 +173,10 @@ def test_multiple_phonopy_to_state(si_phonopy_atoms: Any, device: torch.device) 
     assert state.cell.shape == (2, 3, 3)
     assert state.pbc
     assert state.atomic_numbers.shape == (16,)
-    assert state.batch.shape == (16,)
+    assert state.system_idx.shape == (16,)
     assert torch.all(
-        state.batch == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8),
+        state.system_idx
+        == torch.repeat_interleave(torch.tensor([0, 1], device=device), 8),
     )
 
 
@@ -235,11 +238,11 @@ def test_state_round_trip(
     # Get the sim_state fixture dynamically using the name
     sim_state: ts.SimState = request.getfixturevalue(sim_state_name)
     to_format_fn, from_format_fn = conversion_functions
-    unique_batches = torch.unique(sim_state.batch)
+    unique_systems = torch.unique(sim_state.system_idx)
 
     # Convert to intermediate format
     intermediate_format = to_format_fn(sim_state)
-    assert len(intermediate_format) == len(unique_batches)
+    assert len(intermediate_format) == len(unique_systems)
 
     # Convert back to state
     round_trip_state: ts.SimState = from_format_fn(intermediate_format, device, dtype)
@@ -248,7 +251,7 @@ def test_state_round_trip(
     assert torch.allclose(sim_state.positions, round_trip_state.positions)
     assert torch.allclose(sim_state.cell, round_trip_state.cell)
     assert torch.all(sim_state.atomic_numbers == round_trip_state.atomic_numbers)
-    assert torch.all(sim_state.batch == round_trip_state.batch)
+    assert torch.all(sim_state.system_idx == round_trip_state.system_idx)
     assert sim_state.pbc == round_trip_state.pbc
 
     if isinstance(intermediate_format[0], Atoms):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -149,7 +149,7 @@ def test_integrate_many_nvt(
         lj_model.dtype,
     )
     trajectory_files = [
-        tmp_path / f"nvt_{batch}.h5md" for batch in range(triple_state.n_batches)
+        tmp_path / f"nvt_{batch}.h5md" for batch in range(triple_state.n_systems)
     ]
     reporter = TrajectoryReporter(
         filenames=trajectory_files,
@@ -231,7 +231,7 @@ def test_integrate_with_autobatcher_and_reporting(
         max_memory_scaler=260,
     )
     trajectory_files = [
-        tmp_path / f"nvt_{batch}.h5md" for batch in range(triple_state.n_batches)
+        tmp_path / f"nvt_{batch}.h5md" for batch in range(triple_state.n_systems)
     ]
     reporter = TrajectoryReporter(
         filenames=trajectory_files,
@@ -340,7 +340,7 @@ def test_batched_optimize_fire(
 ) -> None:
     """Test batched FIRE optimization with LJ potential."""
     trajectory_files = [
-        tmp_path / f"nvt_{idx}.h5md" for idx in range(ar_double_sim_state.n_batches)
+        tmp_path / f"nvt_{idx}.h5md" for idx in range(ar_double_sim_state.n_systems)
     ]
     reporter = TrajectoryReporter(
         filenames=trajectory_files,
@@ -414,7 +414,7 @@ def test_optimize_with_autobatcher_and_reporting(
     )
 
     trajectory_files = [
-        tmp_path / f"opt_{batch}.h5md" for batch in range(triple_state.n_batches)
+        tmp_path / f"opt_{batch}.h5md" for batch in range(triple_state.n_systems)
     ]
     reporter = TrajectoryReporter(
         filenames=trajectory_files,
@@ -798,7 +798,7 @@ def test_readme_example(lj_model: LennardJonesModel, tmp_path: Path) -> None:
         # autobatcher=True,  # disabled for CPU-based LJ model in test
     )
 
-    assert relaxed_state.energy.shape == (final_state.n_batches,)
+    assert relaxed_state.energy.shape == (final_state.n_systems,)
 
 
 @pytest.fixture
@@ -806,21 +806,21 @@ def mock_state() -> Callable:
     """Create a mock state for testing convergence functions."""
     device = torch.device("cpu")
     dtype = torch.float64
-    n_batches, n_atoms = 2, 8
+    n_systems, n_atoms = 2, 8
     torch.manual_seed(0)  # deterministic forces
 
     class MockState:
         def __init__(self, *, include_cell_forces: bool = True) -> None:
             self.forces = torch.randn(n_atoms, 3, device=device, dtype=dtype)
-            self.batch = torch.repeat_interleave(
-                torch.arange(n_batches), n_atoms // n_batches
+            self.system_idx = torch.repeat_interleave(
+                torch.arange(n_systems), n_atoms // n_systems
             )
             self.device = device
             self.dtype = dtype
-            self.n_batches = n_batches
+            self.n_systems = n_systems
             if include_cell_forces:
                 self.cell_forces = torch.randn(
-                    n_batches, 3, 3, device=device, dtype=dtype
+                    n_systems, 3, 3, device=device, dtype=dtype
                 )
 
     return MockState
@@ -858,7 +858,7 @@ def test_generate_force_convergence_fn(
 
         if has_cell_forces:
             ar_supercell_sim_state.cell_forces = torch.randn(
-                ar_supercell_sim_state.n_batches,
+                ar_supercell_sim_state.n_systems,
                 3,
                 3,
                 device=ar_supercell_sim_state.device,
@@ -877,7 +877,7 @@ def test_generate_force_convergence_fn(
         result = convergence_fn(state)
         assert isinstance(result, torch.Tensor)
         assert result.dtype == torch.bool
-        assert result.shape == (state.n_batches,)
+        assert result.shape == (state.n_systems,)
 
 
 def test_generate_force_convergence_fn_tolerance_ordering(
@@ -888,7 +888,7 @@ def test_generate_force_convergence_fn_tolerance_ordering(
     ar_supercell_sim_state.forces = model_output["forces"]
     ar_supercell_sim_state.energy = model_output["energy"]
     ar_supercell_sim_state.cell_forces = torch.randn(
-        ar_supercell_sim_state.n_batches,
+        ar_supercell_sim_state.n_systems,
         3,
         3,
         device=ar_supercell_sim_state.device,
@@ -926,26 +926,26 @@ def test_generate_force_convergence_fn_logic(
 ) -> None:
     """Test convergence logic with controlled force values."""
     device, dtype = torch.device("cpu"), torch.float64
-    n_batches, n_atoms = len(atomic_forces), 8
+    n_systems, n_atoms = len(atomic_forces), 8
 
     class ControlledMockState:
         def __init__(self) -> None:
-            self.n_batches = n_batches
+            self.n_systems = n_systems
             self.device, self.dtype = device, dtype
-            self.batch = torch.repeat_interleave(
-                torch.arange(n_batches), n_atoms // n_batches
+            self.system_idx = torch.repeat_interleave(
+                torch.arange(n_systems), n_atoms // n_systems
             )
 
-            # Set specific force magnitudes per batch
+            # Set specific force magnitudes per system
             self.forces = torch.zeros(n_atoms, 3, device=device, dtype=dtype)
-            self.cell_forces = torch.zeros(n_batches, 3, 3, device=device, dtype=dtype)
+            self.cell_forces = torch.zeros(n_systems, 3, 3, device=device, dtype=dtype)
 
-            for batch_idx, (atomic_force, cell_force) in enumerate(
+            for system_idx, (atomic_force, cell_force) in enumerate(
                 zip(atomic_forces, cell_forces, strict=False)
             ):
-                batch_mask = self.batch == batch_idx
-                self.forces[batch_mask, 0] = atomic_force
-                self.cell_forces[batch_idx, 0, 0] = cell_force
+                system_mask = self.system_idx == system_idx
+                self.forces[system_mask, 0] = atomic_force
+                self.cell_forces[system_idx, 0, 0] = cell_force
 
     state = ControlledMockState()
     convergence_fn = ts.generate_force_convergence_fn(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,7 +9,7 @@ from torch_sim.integrators import MDState
 from torch_sim.state import (
     DeformGradMixin,
     SimState,
-    _normalize_batch_indices,
+    _normalize_system_indices,
     _pop_states,
     _slice_state,
     concatenate_states,
@@ -28,8 +28,13 @@ def test_infer_sim_state_property_scope(si_sim_state: ts.SimState) -> None:
     """Test inference of property scope."""
     scope = infer_property_scope(si_sim_state)
     assert set(scope["global"]) == {"pbc"}
-    assert set(scope["per_atom"]) == {"positions", "masses", "atomic_numbers", "batch"}
-    assert set(scope["per_batch"]) == {"cell"}
+    assert set(scope["per_atom"]) == {
+        "positions",
+        "masses",
+        "atomic_numbers",
+        "system_idx",
+    }
+    assert set(scope["per_system"]) == {"cell"}
 
 
 def test_infer_md_state_property_scope(si_sim_state: ts.SimState) -> None:
@@ -46,19 +51,19 @@ def test_infer_md_state_property_scope(si_sim_state: ts.SimState) -> None:
         "positions",
         "masses",
         "atomic_numbers",
-        "batch",
+        "system_idx",
         "forces",
         "momenta",
     }
-    assert set(scope["per_batch"]) == {"cell", "energy"}
+    assert set(scope["per_system"]) == {"cell", "energy"}
 
 
 def test_slice_substate(
     si_double_sim_state: ts.SimState, si_sim_state: ts.SimState
 ) -> None:
     """Test slicing a substate from the SimState."""
-    for batch_index in range(2):
-        substate = _slice_state(si_double_sim_state, [batch_index])
+    for system_index in range(2):
+        substate = _slice_state(si_double_sim_state, [system_index])
         assert isinstance(substate, SimState)
         assert substate.positions.shape == (8, 3)
         assert substate.masses.shape == (8,)
@@ -67,7 +72,7 @@ def test_slice_substate(
         assert torch.allclose(substate.masses, si_sim_state.masses)
         assert torch.allclose(substate.cell, si_sim_state.cell)
         assert torch.allclose(substate.atomic_numbers, si_sim_state.atomic_numbers)
-        assert torch.allclose(substate.batch, torch.zeros_like(substate.batch))
+        assert torch.allclose(substate.system_idx, torch.zeros_like(substate.system_idx))
 
 
 def test_slice_md_substate(si_double_sim_state: ts.SimState) -> None:
@@ -77,8 +82,8 @@ def test_slice_md_substate(si_double_sim_state: ts.SimState) -> None:
         energy=torch.zeros((2,), device=si_double_sim_state.device),
         forces=torch.randn_like(si_double_sim_state.positions),
     )
-    for batch_index in range(2):
-        substate = _slice_state(state, [batch_index])
+    for system_index in range(2):
+        substate = _slice_state(state, [system_index])
         assert isinstance(substate, MDState)
         assert substate.positions.shape == (8, 3)
         assert substate.masses.shape == (8,)
@@ -101,10 +106,10 @@ def test_concatenate_two_si_states(
     assert concatenated.masses.shape == si_double_sim_state.masses.shape
     assert concatenated.cell.shape == si_double_sim_state.cell.shape
     assert concatenated.atomic_numbers.shape == si_double_sim_state.atomic_numbers.shape
-    assert concatenated.batch.shape == si_double_sim_state.batch.shape
+    assert concatenated.system_idx.shape == si_double_sim_state.system_idx.shape
 
-    # Check batch indices
-    expected_batch = torch.cat(
+    # Check system indices
+    expected_system_indices = torch.cat(
         [
             torch.zeros(
                 si_sim_state.n_atoms, dtype=torch.int64, device=si_sim_state.device
@@ -114,12 +119,12 @@ def test_concatenate_two_si_states(
             ),
         ]
     )
-    assert torch.all(concatenated.batch == expected_batch)
+    assert torch.all(concatenated.system_idx == expected_system_indices)
 
-    # Check that positions match (accounting for batch indices)
-    for batch_idx in range(2):
-        mask_concat = concatenated.batch == batch_idx
-        mask_double = si_double_sim_state.batch == batch_idx
+    # Check that positions match (accounting for system indices)
+    for system_idx in range(2):
+        mask_concat = concatenated.system_idx == system_idx
+        mask_double = si_double_sim_state.system_idx == system_idx
         assert torch.allclose(
             concatenated.positions[mask_concat],
             si_double_sim_state.positions[mask_double],
@@ -143,22 +148,22 @@ def test_concatenate_si_and_fe_states(
         concatenated.masses.shape[0]
         == si_sim_state.masses.shape[0] + fe_supercell_sim_state.masses.shape[0]
     )
-    assert concatenated.cell.shape[0] == 2  # One cell per batch
+    assert concatenated.cell.shape[0] == 2  # One cell per system
 
-    # Check batch indices
+    # Check system indices
     si_atoms = si_sim_state.n_atoms
     fe_atoms = fe_supercell_sim_state.n_atoms
-    expected_batch = torch.cat(
+    expected_system_indices = torch.cat(
         [
             torch.zeros(si_atoms, dtype=torch.int64, device=si_sim_state.device),
             torch.ones(fe_atoms, dtype=torch.int64, device=fe_supercell_sim_state.device),
         ]
     )
-    assert torch.all(concatenated.batch == expected_batch)
+    assert torch.all(concatenated.system_idx == expected_system_indices)
 
-    # check n_atoms_per_batch
+    # check n_atoms_per_system
     assert torch.all(
-        concatenated.n_atoms_per_batch
+        concatenated.n_atoms_per_system
         == torch.tensor(
             [si_sim_state.n_atoms, fe_supercell_sim_state.n_atoms],
             device=concatenated.device,
@@ -192,22 +197,22 @@ def test_concatenate_double_si_and_fe_states(
     )
     assert (
         concatenated.cell.shape[0] == 3
-    )  # One cell for each original batch (2 Si + 1 Ar)
+    )  # One cell for each original system (2 Si + 1 Ar)
 
-    # Check batch indices
+    # Check system indices
     fe_atoms = fe_supercell_sim_state.n_atoms
 
-    # The double Si state already has batches 0 and 1, so Ar should be batch 2
-    expected_batch = torch.cat(
+    # The double Si state already has systems 0 and 1, so Ar should be system 2
+    expected_system_indices = torch.cat(
         [
-            si_double_sim_state.batch,
+            si_double_sim_state.system_idx,
             torch.full(
                 (fe_atoms,), 2, dtype=torch.int64, device=fe_supercell_sim_state.device
             ),
         ]
     )
-    assert torch.all(concatenated.batch == expected_batch)
-    assert torch.unique(concatenated.batch).shape[0] == 3
+    assert torch.all(concatenated.system_idx == expected_system_indices)
+    assert torch.unique(concatenated.system_idx).shape[0] == 3
 
     # Check that we can slice back to the original states
     si_slice_0 = concatenated[0]
@@ -223,14 +228,14 @@ def test_concatenate_double_si_and_fe_states(
 def test_split_state(si_double_sim_state: ts.SimState) -> None:
     """Test splitting a state into a list of states."""
     states = si_double_sim_state.split()
-    assert len(states) == si_double_sim_state.n_batches
+    assert len(states) == si_double_sim_state.n_systems
     for state in states:
         assert isinstance(state, ts.SimState)
         assert state.positions.shape == (8, 3)
         assert state.masses.shape == (8,)
         assert state.cell.shape == (1, 3, 3)
         assert state.atomic_numbers.shape == (8,)
-        assert torch.allclose(state.batch, torch.zeros_like(state.batch))
+        assert torch.allclose(state.system_idx, torch.zeros_like(state.system_idx))
 
 
 def test_split_many_states(
@@ -248,7 +253,7 @@ def test_split_many_states(
         assert torch.allclose(sub_state.masses, state.masses)
         assert torch.allclose(sub_state.cell, state.cell)
         assert torch.allclose(sub_state.atomic_numbers, state.atomic_numbers)
-        assert torch.allclose(sub_state.batch, state.batch)
+        assert torch.allclose(sub_state.system_idx, state.system_idx)
 
     assert len(states) == 3
 
@@ -276,7 +281,7 @@ def test_pop_states(
     assert kept_state.masses.shape == (len_kept,)
     assert kept_state.cell.shape == (2, 3, 3)
     assert kept_state.atomic_numbers.shape == (len_kept,)
-    assert kept_state.batch.shape == (len_kept,)
+    assert kept_state.system_idx.shape == (len_kept,)
 
 
 def test_initialize_state_from_structure(
@@ -337,8 +342,8 @@ def test_state_pop_method(
     assert torch.allclose(popped_states[0].positions, ar_supercell_sim_state.positions)
 
     # Verify the original state was modified
-    assert concatenated.n_batches == 2
-    assert torch.unique(concatenated.batch).tolist() == [0, 1]
+    assert concatenated.n_systems == 2
+    assert torch.unique(concatenated.system_idx).tolist() == [0, 1]
 
     # Test popping multiple batches
     multi_state = concatenate_states(states)
@@ -348,8 +353,8 @@ def test_state_pop_method(
     assert torch.allclose(popped_multi[1].positions, fe_supercell_sim_state.positions)
 
     # Verify the original multi-state was modified
-    assert multi_state.n_batches == 1
-    assert torch.unique(multi_state.batch).tolist() == [0]
+    assert multi_state.n_systems == 1
+    assert torch.unique(multi_state.system_idx).tolist() == [0]
     assert torch.allclose(multi_state.positions, ar_supercell_sim_state.positions)
 
 
@@ -367,19 +372,19 @@ def test_state_getitem(
     single_state = concatenated[1]
     assert isinstance(single_state, SimState)
     assert torch.allclose(single_state.positions, ar_supercell_sim_state.positions)
-    assert single_state.n_batches == 1
+    assert single_state.n_systems == 1
 
     # Test list indexing
     multi_state = concatenated[[0, 2]]
     assert isinstance(multi_state, SimState)
-    assert multi_state.n_batches == 2
+    assert multi_state.n_systems == 2
     assert torch.allclose(multi_state[0].positions, si_sim_state.positions)
     assert torch.allclose(multi_state[1].positions, fe_supercell_sim_state.positions)
 
     # Test slice indexing
     slice_state = concatenated[1:3]
     assert isinstance(slice_state, SimState)
-    assert slice_state.n_batches == 2
+    assert slice_state.n_systems == 2
     assert torch.allclose(slice_state[0].positions, ar_supercell_sim_state.positions)
     assert torch.allclose(slice_state[1].positions, fe_supercell_sim_state.positions)
 
@@ -391,67 +396,67 @@ def test_state_getitem(
     # Test step in slice
     step_state = concatenated[::2]
     assert isinstance(step_state, SimState)
-    assert step_state.n_batches == 2
+    assert step_state.n_systems == 2
     assert torch.allclose(step_state[0].positions, si_sim_state.positions)
     assert torch.allclose(step_state[1].positions, fe_supercell_sim_state.positions)
 
     full_state = concatenated[:]
     assert torch.allclose(full_state.positions, concatenated.positions)
     # Verify original state is unchanged
-    assert concatenated.n_batches == 3
+    assert concatenated.n_systems == 3
 
 
-def test_normalize_batch_indices(si_double_sim_state: ts.SimState) -> None:
-    """Test the _normalize_batch_indices utility method."""
+def test_normalize_system_indices(si_double_sim_state: ts.SimState) -> None:
+    """Test the _normalize_system_indices utility method."""
     state = si_double_sim_state  # State with 2 batches
-    n_batches = state.n_batches
+    n_systems = state.n_systems
     device = state.device
 
     # Test integer indexing
-    assert _normalize_batch_indices(0, n_batches, device).tolist() == [0]
-    assert _normalize_batch_indices(1, n_batches, device).tolist() == [1]
+    assert _normalize_system_indices(0, n_systems, device).tolist() == [0]
+    assert _normalize_system_indices(1, n_systems, device).tolist() == [1]
 
     # Test negative integer indexing
-    assert _normalize_batch_indices(-1, n_batches, device).tolist() == [1]
-    assert _normalize_batch_indices(-2, n_batches, device).tolist() == [0]
+    assert _normalize_system_indices(-1, n_systems, device).tolist() == [1]
+    assert _normalize_system_indices(-2, n_systems, device).tolist() == [0]
 
     # Test list indexing
-    assert _normalize_batch_indices([0, 1], n_batches, device).tolist() == [0, 1]
+    assert _normalize_system_indices([0, 1], n_systems, device).tolist() == [0, 1]
 
     # Test list with negative indices
-    assert _normalize_batch_indices([0, -1], n_batches, device).tolist() == [0, 1]
-    assert _normalize_batch_indices([-2, -1], n_batches, device).tolist() == [0, 1]
+    assert _normalize_system_indices([0, -1], n_systems, device).tolist() == [0, 1]
+    assert _normalize_system_indices([-2, -1], n_systems, device).tolist() == [0, 1]
 
     # Test slice indexing
-    indices = _normalize_batch_indices(slice(0, 2), n_batches, device)
+    indices = _normalize_system_indices(slice(0, 2), n_systems, device)
     assert isinstance(indices, torch.Tensor)
     assert torch.all(indices == torch.tensor([0, 1], device=state.device))
 
     # Test slice with negative indices
-    indices = _normalize_batch_indices(slice(-2, None), n_batches, device)
+    indices = _normalize_system_indices(slice(-2, None), n_systems, device)
     assert isinstance(indices, torch.Tensor)
     assert torch.all(indices == torch.tensor([0, 1], device=state.device))
 
     # Test slice with step
-    indices = _normalize_batch_indices(slice(0, 2, 2), n_batches, device)
+    indices = _normalize_system_indices(slice(0, 2, 2), n_systems, device)
     assert isinstance(indices, torch.Tensor)
     assert torch.all(indices == torch.tensor([0], device=state.device))
 
     # Test tensor indexing
     tensor_indices = torch.tensor([0, 1], device=state.device)
-    indices = _normalize_batch_indices(tensor_indices, n_batches, device)
+    indices = _normalize_system_indices(tensor_indices, n_systems, device)
     assert isinstance(indices, torch.Tensor)
     assert torch.all(indices == tensor_indices)
 
     # Test tensor with negative indices
     tensor_indices = torch.tensor([0, -1], device=state.device)
-    indices = _normalize_batch_indices(tensor_indices, n_batches, device)
+    indices = _normalize_system_indices(tensor_indices, n_systems, device)
     assert isinstance(indices, torch.Tensor)
     assert torch.all(indices == torch.tensor([0, 1], device=state.device))
 
     # Test error for unsupported type
     try:
-        _normalize_batch_indices((0, 1), n_batches, device)  # Tuple is not supported
+        _normalize_system_indices((0, 1), n_systems, device)  # Tuple is not supported
         raise ValueError("Should have raised TypeError")
     except TypeError:
         pass
@@ -601,7 +606,9 @@ def test_deform_grad_batched(device: torch.device) -> None:
         atomic_numbers=torch.ones(n_atoms * batch_size, device=device, dtype=torch.long),
         velocities=torch.randn(n_atoms * batch_size, 3, device=device),
         reference_cell=reference_cell,
-        batch=torch.repeat_interleave(torch.arange(batch_size, device=device), n_atoms),
+        system_idx=torch.repeat_interleave(
+            torch.arange(batch_size, device=device), n_atoms
+        ),
     )
 
     deform_grad = state.deform_grad()
@@ -611,3 +618,28 @@ def test_deform_grad_batched(device: torch.device) -> None:
     for i in range(batch_size):
         expected = expected_factors[i] * torch.eye(3, device=device)
         assert torch.allclose(deform_grad[i], expected)
+
+
+def test_deprecated_batch_properties_equal_to_new_system_properties(
+    device: torch.device,
+) -> None:
+    """Test that deprecated batch properties are equal to new system properties.
+
+    This tests that the rename from batch to system is not breaking anything."""
+    state = SimState(
+        positions=torch.randn(10, 3, device=device),
+        masses=torch.ones(10, device=device),
+        cell=torch.eye(3, device=device).unsqueeze(0).repeat(2, 1, 1),
+        pbc=True,
+        atomic_numbers=torch.ones(10, device=device, dtype=torch.long),
+        system_idx=torch.repeat_interleave(torch.arange(2, device=device), 5),
+    )
+    assert state.batch is state.system_idx
+    assert state.n_batches == state.n_systems
+    assert torch.allclose(state.n_atoms_per_batch, state.n_atoms_per_system)
+
+    # now test that assigning the old .batch property behaves the same
+    new_system_idx = torch.arange(4, device=device)
+    state.batch = new_system_idx
+    assert torch.allclose(state.system_idx, new_system_idx)
+    assert torch.allclose(state.batch, new_system_idx)

--- a/torch_sim/integrators/nve.py
+++ b/torch_sim/integrators/nve.py
@@ -37,9 +37,9 @@ def nve(
     Args:
         model (torch.nn.Module): Neural network model that computes energies and forces.
             Must return a dict with 'energy' and 'forces' keys.
-        dt (torch.Tensor): Integration timestep, either scalar or with shape [n_batches]
+        dt (torch.Tensor): Integration timestep, either scalar or with shape [n_systems]
         kT (torch.Tensor): Temperature in energy units for initializing momenta,
-            either scalar or with shape [n_batches]
+            either scalar or with shape [n_systems]
         seed (int, optional): Random seed for reproducibility. Defaults to None.
 
     Returns:
@@ -72,7 +72,7 @@ def nve(
                 containing positions, masses, cell, pbc, and other required state
                 variables
             kT (torch.Tensor): Temperature in energy units for initializing momenta,
-                scalar or with shape [n_batches]
+                scalar or with shape [n_systems]
             seed (int, optional): Random seed for reproducibility
 
         Returns:
@@ -88,7 +88,7 @@ def nve(
         momenta = getattr(
             state,
             "momenta",
-            calculate_momenta(state.positions, state.masses, state.batch, kT, seed),
+            calculate_momenta(state.positions, state.masses, state.system_idx, kT, seed),
         )
 
         initial_state = MDState(
@@ -99,7 +99,7 @@ def nve(
             masses=state.masses,
             cell=state.cell,
             pbc=state.pbc,
-            batch=state.batch,
+            system_idx=state.system_idx,
             atomic_numbers=state.atomic_numbers,
         )
         return initial_state  # noqa: RET504
@@ -116,7 +116,7 @@ def nve(
 
         Args:
             state (MDState): Current system state containing positions, momenta, forces
-            dt (torch.Tensor): Integration timestep, either scalar or shape [n_batches]
+            dt (torch.Tensor): Integration timestep, either scalar or shape [n_systems]
             **_: Additional unused keyword arguments (for compatibility)
 
         Returns:

--- a/torch_sim/math.py
+++ b/torch_sim/math.py
@@ -1000,7 +1000,7 @@ def batched_vdot(
         batch_indices: Tensor of shape [N_total_entities] indicating batch membership.
 
     Returns:
-        Tensor: shape [n_batches] where each element is the sum(x_i * y_i)
+        Tensor: shape [n_systems] where each element is the sum(x_i * y_i)
     for entities belonging to that batch,
         summed over all components D and all entities in the batch.
     """

--- a/torch_sim/models/fairchem.py
+++ b/torch_sim/models/fairchem.py
@@ -349,8 +349,8 @@ class FairChemModel(torch.nn.Module, ModelInterface):
         if state.device != self._device:
             state = state.to(self._device)
 
-        if state.batch is None:
-            state.batch = torch.zeros(state.positions.shape[0], dtype=torch.int)
+        if state.system_idx is None:
+            state.system_idx = torch.zeros(state.positions.shape[0], dtype=torch.int)
 
         if self.pbc != state.pbc:
             raise ValueError(
@@ -358,8 +358,8 @@ class FairChemModel(torch.nn.Module, ModelInterface):
                 "For FairChemModel PBC needs to be defined in the model class."
             )
 
-        natoms = torch.bincount(state.batch)
-        fixed = torch.zeros((state.batch.size(0), natoms.sum()), dtype=torch.int)
+        natoms = torch.bincount(state.system_idx)
+        fixed = torch.zeros((state.system_idx.size(0), natoms.sum()), dtype=torch.int)
         data_list = []
         for i, (n, c) in enumerate(
             zip(natoms, torch.cumsum(natoms, dim=0), strict=False)

--- a/torch_sim/models/graphpes.py
+++ b/torch_sim/models/graphpes.py
@@ -67,8 +67,8 @@ def state_to_atomic_graph(state: ts.SimState, cutoff: torch.Tensor) -> AtomicGra
     """
     graphs = []
 
-    for i in range(state.n_batches):
-        batch_mask = state.batch == i
+    for i in range(state.n_systems):
+        batch_mask = state.system_idx == i
         R = state.positions[batch_mask]
         Z = state.atomic_numbers[batch_mask]
         cell = state.row_vector_cell[i]

--- a/torch_sim/models/interface.py
+++ b/torch_sim/models/interface.py
@@ -65,9 +65,9 @@ class ModelInterface(ABC):
         output = model(sim_state)
 
         # Access computed properties
-        energy = output["energy"]  # Shape: [n_batches]
+        energy = output["energy"]  # Shape: [n_systems]
         forces = output["forces"]  # Shape: [n_atoms, 3]
-        stress = output["stress"]  # Shape: [n_batches, 3, 3]
+        stress = output["stress"]  # Shape: [n_systems, 3, 3]
         ```
     """
 
@@ -174,16 +174,16 @@ class ModelInterface(ABC):
                 dictionary is dependent on the model but typically must contain the
                 following keys:
                 - "positions": Atomic positions with shape [n_atoms, 3]
-                - "cell": Unit cell vectors with shape [n_batches, 3, 3]
-                - "batch": Batch indices for each atom with shape [n_atoms]
+                - "cell": Unit cell vectors with shape [n_systems, 3, 3]
+                - "system_idx": System indices for each atom with shape [n_atoms]
                 - "atomic_numbers": Atomic numbers with shape [n_atoms] (optional)
             **kwargs: Additional model-specific parameters.
 
         Returns:
             dict[str, torch.Tensor]: Computed properties:
-                - "energy": Potential energy with shape [n_batches]
+                - "energy": Potential energy with shape [n_systems]
                 - "forces": Atomic forces with shape [n_atoms, 3]
-                - "stress": Stress tensor with shape [n_batches, 3, 3] (if
+                - "stress": Stress tensor with shape [n_systems, 3, 3] (if
                     compute_stress=True)
                 - May include additional model-specific outputs
 
@@ -256,7 +256,7 @@ def validate_model_outputs(  # noqa: C901, PLR0915
 
     og_positions = sim_state.positions.clone()
     og_cell = sim_state.cell.clone()
-    og_batch = sim_state.batch.clone()
+    og_system_idx = sim_state.system_idx.clone()
     og_atomic_numbers = sim_state.atomic_numbers.clone()
 
     model_output = model.forward(sim_state)
@@ -266,8 +266,8 @@ def validate_model_outputs(  # noqa: C901, PLR0915
         raise ValueError(f"{og_positions=} != {sim_state.positions=}")
     if not torch.allclose(og_cell, sim_state.cell):
         raise ValueError(f"{og_cell=} != {sim_state.cell=}")
-    if not torch.allclose(og_batch, sim_state.batch):
-        raise ValueError(f"{og_batch=} != {sim_state.batch=}")
+    if not torch.allclose(og_system_idx, sim_state.system_idx):
+        raise ValueError(f"{og_system_idx=} != {sim_state.system_idx=}")
     if not torch.allclose(og_atomic_numbers, sim_state.atomic_numbers):
         raise ValueError(f"{og_atomic_numbers=} != {sim_state.atomic_numbers=}")
 

--- a/torch_sim/models/metatomic.py
+++ b/torch_sim/models/metatomic.py
@@ -74,7 +74,7 @@ class MetatomicModel(torch.nn.Module, ModelInterface):
 
         Sets up a metatomic model for energy, force, and stress calculations within
         the TorchSim framework. The model can be initialized with atomic numbers
-        and batch indices, or these can be provided during the forward pass.
+        and system indices, or these can be provided during the forward pass.
 
         Args:
             model (str | Path | None): Path to the metatomic model file or a
@@ -200,7 +200,7 @@ class MetatomicModel(torch.nn.Module, ModelInterface):
         systems: list[System] = []
         strains = []
         for b in range(len(cell)):
-            system_mask = state.batch == b
+            system_mask = state.system_idx == b
             system_positions = positions[system_mask]
             system_cell = cell[b]
             system_pbc = torch.tensor(

--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -102,7 +102,7 @@ def state_to_atom_graphs(  # noqa: PLR0915
         system_config = SystemConfig(radius=6.0, max_num_neighbors=20)
 
     # Handle batch information if present
-    n_node = torch.bincount(state.batch)
+    n_node = torch.bincount(state.system_idx)
 
     # Set default dtype if not provided
     output_dtype = torch.get_default_dtype() if output_dtype is None else output_dtype
@@ -143,7 +143,7 @@ def state_to_atom_graphs(  # noqa: PLR0915
     if wrap and (torch.any(row_vector_cell != 0) and torch.any(pbc)):
         positions = feat_util.batch_map_to_pbc_cell(positions, row_vector_cell, n_node)
 
-    n_systems = state.batch.max().item() + 1
+    n_systems = state.system_idx.max().item() + 1
 
     # Prepare lists to collect data from each system
     all_edges = []
@@ -157,7 +157,7 @@ def state_to_atom_graphs(  # noqa: PLR0915
     # Process each system in a single loop
     offset = 0
     for i in range(n_systems):
-        batch_mask = state.batch == i
+        batch_mask = state.system_idx == i
         positions_per_system = positions[batch_mask]
         atomic_numbers_per_system = atomic_numbers[batch_mask]
         atomic_numbers_embedding_per_system = atomic_numbers_embedding[batch_mask]

--- a/torch_sim/models/particle_life.py
+++ b/torch_sim/models/particle_life.py
@@ -223,10 +223,10 @@ class ParticleLifeModel(torch.nn.Module, ModelInterface):
 
         Returns:
             dict[str, torch.Tensor]: Computed properties:
-                - "energy": Potential energy with shape [n_batches]
+                - "energy": Potential energy with shape [n_systems]
                 - "forces": Atomic forces with shape [n_atoms, 3] (if
                     compute_forces=True)
-                - "stress": Stress tensor with shape [n_batches, 3, 3] (if
+                - "stress": Stress tensor with shape [n_systems, 3, 3] (if
                     compute_stress=True)
                 - "energies": Per-atom energies with shape [n_atoms] (if
                     per_atom_energies=True)
@@ -239,10 +239,12 @@ class ParticleLifeModel(torch.nn.Module, ModelInterface):
         if isinstance(state, dict):
             state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
-        if state.batch is None and state.cell.shape[0] > 1:
-            raise ValueError("Batch can only be inferred for batch size 1.")
+        if state.system_idx is None and state.cell.shape[0] > 1:
+            raise ValueError(
+                "system_idx can only be inferred if there is only one system."
+            )
 
-        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_batches)]
+        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_systems)]
         properties = outputs[0]
 
         # we always return tensors

--- a/torch_sim/models/sevennet.py
+++ b/torch_sim/models/sevennet.py
@@ -181,8 +181,8 @@ class SevenNetModel(torch.nn.Module, ModelInterface):
         state = state.clone()
 
         data_list = []
-        for b in range(state.batch.max().item() + 1):
-            batch_mask = state.batch == b
+        for b in range(state.system_idx.max().item() + 1):
+            batch_mask = state.system_idx == b
 
             pos = state.positions[batch_mask]
             # SevenNet uses row vector cell convention for neighbor list
@@ -245,7 +245,7 @@ class SevenNetModel(torch.nn.Module, ModelInterface):
             results["energy"] = energy.detach()
         else:
             results["energy"] = torch.zeros(
-                state.batch.max().item() + 1, device=self.device
+                state.system_idx.max().item() + 1, device=self.device
             )
 
         forces = output[key.PRED_FORCE]

--- a/torch_sim/models/soft_sphere.py
+++ b/torch_sim/models/soft_sphere.py
@@ -381,7 +381,7 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
         """Compute soft sphere potential energies, forces, and stresses for a system.
 
         Main entry point for soft sphere potential calculations that handles batched
-        states by dispatching each batch to the unbatched implementation and combining
+        states by dispatching each system to the unbatched implementation and combining
         results.
 
         Args:
@@ -391,15 +391,15 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
 
         Returns:
             dict[str, torch.Tensor]: Computed properties:
-                - "energy": Potential energy with shape [n_batches]
+                - "energy": Potential energy with shape [n_systems]
                 - "forces": Atomic forces with shape [n_atoms, 3]
                     (if compute_forces=True)
-                - "stress": Stress tensor with shape [n_batches, 3, 3]
+                - "stress": Stress tensor with shape [n_systems, 3, 3]
                     (if compute_stress=True)
                 - May include additional outputs based on configuration
 
         Raises:
-            ValueError: If batch cannot be inferred for multi-cell systems.
+            ValueError: If system indices cannot be inferred for multi-cell systems.
 
         Examples:
             ```py
@@ -407,18 +407,20 @@ class SoftSphereModel(torch.nn.Module, ModelInterface):
             model = SoftSphereModel(compute_forces=True)
             results = model(sim_state)
 
-            energy = results["energy"]  # Shape: [n_batches]
+            energy = results["energy"]  # Shape: [n_systems]
             forces = results["forces"]  # Shape: [n_atoms, 3]
             ```
         """
         if isinstance(state, dict):
             state = ts.SimState(**state, masses=torch.ones_like(state["positions"]))
 
-        # Handle batch indices if not provided
-        if state.batch is None and state.cell.shape[0] > 1:
-            raise ValueError("Batch can only be inferred for batch size 1.")
+        # Handle System indices if not provided
+        if state.system_idx is None and state.cell.shape[0] > 1:
+            raise ValueError(
+                "system_idx can only be inferred if there is only one system"
+            )
 
-        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_batches)]
+        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_systems)]
         properties = outputs[0]
 
         # Combine results
@@ -816,10 +818,10 @@ class SoftSphereMultiModel(torch.nn.Module):
 
         Returns:
             dict[str, torch.Tensor]: Computed properties:
-                - "energy": Potential energy with shape [n_batches]
+                - "energy": Potential energy with shape [n_systems]
                 - "forces": Atomic forces with shape [n_atoms, 3]
                     (if compute_forces=True)
-                - "stress": Stress tensor with shape [n_batches, 3, 3]
+                - "stress": Stress tensor with shape [n_systems, 3, 3]
                     (if compute_stress=True)
                 - May include additional outputs based on configuration
 
@@ -854,11 +856,13 @@ class SoftSphereMultiModel(torch.nn.Module):
         elif state.pbc != self.pbc:
             raise ValueError("PBC mismatch between model and state")
 
-        # Handle batch indices if not provided
-        if state.batch is None and state.cell.shape[0] > 1:
-            raise ValueError("Batch can only be inferred for batch size 1.")
+        # Handle system indices if not provided
+        if state.system_idx is None and state.cell.shape[0] > 1:
+            raise ValueError(
+                "system_idx can only be inferred if there is only one system"
+            )
 
-        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_batches)]
+        outputs = [self.unbatched_forward(state[i]) for i in range(state.n_systems)]
         properties = outputs[0]
 
         # Combine results

--- a/torch_sim/neighbors.py
+++ b/torch_sim/neighbors.py
@@ -766,7 +766,7 @@ def torch_nl_linked_cell(
     positions: torch.Tensor,
     cell: torch.Tensor,
     pbc: torch.Tensor,
-    batch: torch.Tensor,
+    system_idx: torch.Tensor,
     self_interaction: bool = False,  # noqa: FBT001, FBT002
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute the neighbor list for a set of atomic structures using the linked
@@ -784,7 +784,7 @@ def torch_nl_linked_cell(
         pbc (torch.Tensor [n_structure, 3] bool):
             A tensor indicating the periodic boundary conditions to apply.
             Partial PBC are not supported yet.
-        batch (torch.Tensor [n_atom,] torch.long):
+        system_idx (torch.Tensor [n_atom,] torch.long):
             A tensor containing the index of the structure to which each atom belongs.
         self_interaction (bool, optional):
             A flag to indicate whether to keep the center atoms as their own neighbors.
@@ -806,7 +806,7 @@ def torch_nl_linked_cell(
     References:
         - https://github.com/felixmusil/torch_nl
     """
-    n_atoms = torch.bincount(batch)
+    n_atoms = torch.bincount(system_idx)
     mapping, batch_mapping, shifts_idx = transforms.build_linked_cell_neighborhood(
         positions, cell, pbc, cutoff, n_atoms, self_interaction
     )

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -172,7 +172,7 @@ def integrate(
         pbar_kwargs = pbar if isinstance(pbar, dict) else {}
         pbar_kwargs.setdefault("desc", "Integrate")
         pbar_kwargs.setdefault("disable", None)
-        tqdm_pbar = tqdm(total=state.n_batches, **pbar_kwargs)
+        tqdm_pbar = tqdm(total=state.n_systems, **pbar_kwargs)
 
     for state, batch_indices in batch_iterator:
         state = init_fn(state)
@@ -194,7 +194,7 @@ def integrate(
         # finish the trajectory reporter
         final_states.append(state)
         if tqdm_pbar:
-            tqdm_pbar.update(state.n_batches)
+            tqdm_pbar.update(state.n_systems)
 
     if trajectory_reporter:
         trajectory_reporter.finish()
@@ -307,7 +307,7 @@ def generate_force_convergence_fn(
         """Check if the system has converged.
 
         Returns:
-            torch.Tensor: Boolean tensor of shape (n_batches,) indicating
+            torch.Tensor: Boolean tensor of shape (n_systems,) indicating
                 convergence status for each batch.
         """
         force_conv = batchwise_max_force(state) < force_tol
@@ -343,7 +343,7 @@ def generate_energy_convergence_fn(energy_tol: float = 1e-3) -> Callable:
         """Check if the system has converged.
 
         Returns:
-            torch.Tensor: Boolean tensor of shape (n_batches,) indicating
+            torch.Tensor: Boolean tensor of shape (n_systems,) indicating
                 convergence status for each batch.
         """
         return torch.abs(state.energy - last_energy) < energy_tol
@@ -372,7 +372,7 @@ def optimize(  # noqa: C901
         model (ModelInterface): Neural network model module
         optimizer (Callable): Optimization algorithm function
         convergence_fn (Callable | None): Condition for convergence, should return a
-            boolean tensor of length n_batches
+            boolean tensor of length n_systems
         optimizer_kwargs: Additional keyword arguments for optimizer init function
         trajectory_reporter (TrajectoryReporter | dict | None): Optional reporter for
             tracking optimization trajectory. If a dict, will be passed to the
@@ -434,7 +434,7 @@ def optimize(  # noqa: C901
         pbar_kwargs = pbar if isinstance(pbar, dict) else {}
         pbar_kwargs.setdefault("desc", "Optimize")
         pbar_kwargs.setdefault("disable", None)
-        tqdm_pbar = tqdm(total=state.n_batches, **pbar_kwargs)
+        tqdm_pbar = tqdm(total=state.n_systems, **pbar_kwargs)
 
     while (result := autobatcher.next_batch(state, convergence_tensor))[0] is not None:
         state, converged_states, batch_indices = result
@@ -545,7 +545,7 @@ def static(
         pbar_kwargs = pbar if isinstance(pbar, dict) else {}
         pbar_kwargs.setdefault("desc", "Static")
         pbar_kwargs.setdefault("disable", None)
-        tqdm_pbar = tqdm(total=state.n_batches, **pbar_kwargs)
+        tqdm_pbar = tqdm(total=state.n_systems, **pbar_kwargs)
 
     for sub_state, batch_indices in batch_iterator:
         # set up trajectory reporters
@@ -568,7 +568,7 @@ def static(
         all_props.extend(props)
 
         if tqdm_pbar:
-            tqdm_pbar.update(sub_state.n_batches)
+            tqdm_pbar.update(sub_state.n_systems)
 
     trajectory_reporter.finish()
 

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -29,48 +29,49 @@ class SimState:
     Contains the fundamental properties needed to describe an atomistic system:
     positions, masses, unit cell, periodic boundary conditions, and atomic numbers.
     Supports batched operations where multiple atomistic systems can be processed
-    simultaneously, managed through batch indices.
+    simultaneously, managed through system indices.
 
     States support slicing, cloning, splitting, popping, and movement to other
     data structures or devices. Slicing is supported through fancy indexing,
     e.g. `state[[0, 1, 2]]` will return a new state containing only the first three
-    batches. The other operations are available through the `pop`, `split`, `clone`,
+    systems. The other operations are available through the `pop`, `split`, `clone`,
     and `to` methods.
 
     Attributes:
         positions (torch.Tensor): Atomic positions with shape (n_atoms, 3)
         masses (torch.Tensor): Atomic masses with shape (n_atoms,)
-        cell (torch.Tensor): Unit cell vectors with shape (n_batches, 3, 3).
+        cell (torch.Tensor): Unit cell vectors with shape (n_systems, 3, 3).
             Note that we use a column vector convention, i.e. the cell vectors are
             stored as `[[a1, b1, c1], [a2, b2, c2], [a3, b3, c3]]` as opposed to
             the row vector convention `[[a1, a2, a3], [b1, b2, b3], [c1, c2, c3]]`
             used by ASE.
         pbc (bool): Boolean indicating whether to use periodic boundary conditions
         atomic_numbers (torch.Tensor): Atomic numbers with shape (n_atoms,)
-        batch (torch.Tensor, optional): Batch indices with shape (n_atoms,),
-            defaults to None, must be unique consecutive integers starting from 0
+        system_idx (torch.Tensor, optional): Maps each atom index to its system index.
+            Has shape (n_atoms,), defaults to None, must be unique consecutive
+            integers starting from 0
 
     Properties:
         wrap_positions (torch.Tensor): Positions wrapped according to periodic boundary
             conditions
         device (torch.device): Device of the positions tensor
         dtype (torch.dtype): Data type of the positions tensor
-        n_atoms (int): Total number of atoms across all batches
-        n_batches (int): Number of unique batches in the system
+        n_atoms (int): Total number of atoms across all systems
+        n_systems (int): Number of unique systems in the system
 
     Notes:
         - positions, masses, and atomic_numbers must have shape (n_atoms, 3).
         - cell must be in the conventional matrix form.
-        - batch indices must be unique consecutive integers starting from 0.
+        - system indices must be unique consecutive integers starting from 0.
 
     Examples:
         >>> state = initialize_state(
         ...     [ase_atoms_1, ase_atoms_2, ase_atoms_3], device, dtype
         ... )
-        >>> state.n_batches
+        >>> state.n_systems
         3
         >>> new_state = state[[0, 1]]
-        >>> new_state.n_batches
+        >>> new_state.n_systems
         2
         >>> cloned_state = state.clone()
     """
@@ -80,11 +81,11 @@ class SimState:
     cell: torch.Tensor
     pbc: bool  # TODO: do all calculators support mixed pbc?
     atomic_numbers: torch.Tensor
-    batch: torch.Tensor | None = field(default=None, kw_only=True)
+    system_idx: torch.Tensor | None = field(default=None, kw_only=True)
 
     def __post_init__(self) -> None:
         """Validate and process the state after initialization."""
-        # data validation and fill batch
+        # data validation and fill system_idx
         # should make pbc a tensor here
         # if devices aren't all the same, raise an error, in a clean way
         devices = {
@@ -106,23 +107,27 @@ class SimState:
                 f"masses {shapes[1]}, atomic_numbers {shapes[2]}"
             )
 
-        if self.cell.ndim != 3 and self.batch is None:
+        if self.cell.ndim != 3 and self.system_idx is None:
             self.cell = self.cell.unsqueeze(0)
 
         if self.cell.shape[-2:] != (3, 3):
-            raise ValueError("Cell must have shape (n_batches, 3, 3)")
+            raise ValueError("Cell must have shape (n_systems, 3, 3)")
 
-        if self.batch is None:
-            self.batch = torch.zeros(self.n_atoms, device=self.device, dtype=torch.int64)
+        if self.system_idx is None:
+            self.system_idx = torch.zeros(
+                self.n_atoms, device=self.device, dtype=torch.int64
+            )
         else:
-            # assert that batch indices are unique consecutive integers
-            _, counts = torch.unique_consecutive(self.batch, return_counts=True)
-            if not torch.all(counts == torch.bincount(self.batch)):
-                raise ValueError("Batch indices must be unique consecutive integers")
+            # assert that system indices are unique consecutive integers
+            # TODO(curtis): I feel like this logic is not reliable.
+            # I'll come up with something better later.
+            _, counts = torch.unique_consecutive(self.system_idx, return_counts=True)
+            if not torch.all(counts == torch.bincount(self.system_idx)):
+                raise ValueError("System indices must be unique consecutive integers")
 
-        if self.cell.shape[0] != self.n_batches:
+        if self.cell.shape[0] != self.n_systems:
             raise ValueError(
-                f"Cell must have shape (n_batches, 3, 3), got {self.cell.shape}"
+                f"Cell must have shape (n_systems, 3, 3), got {self.cell.shape}"
             )
 
     @property
@@ -145,22 +150,58 @@ class SimState:
 
     @property
     def n_atoms(self) -> int:
-        """Total number of atoms in the system across all batches."""
+        """Total number of atoms in the system across all systems."""
         return self.positions.shape[0]
 
     @property
-    def n_atoms_per_batch(self) -> torch.Tensor:
-        """Number of atoms per batch."""
+    def n_atoms_per_system(self) -> torch.Tensor:
+        """Number of atoms per system."""
         return (
-            self.batch.bincount()
-            if self.batch is not None
+            self.system_idx.bincount()
+            if self.system_idx is not None
             else torch.tensor([self.n_atoms], device=self.device)
         )
 
     @property
+    def n_atoms_per_batch(self) -> torch.Tensor:
+        """Number of atoms per batch.
+
+        deprecated::
+            Use :attr:`n_atoms_per_system` instead.
+        """
+        return self.n_atoms_per_system
+
+    @property
+    def batch(self) -> torch.Tensor | None:
+        """System indices.
+
+        deprecated::
+            Use :attr:`system_idx` instead.
+        """
+        return self.system_idx
+
+    @batch.setter
+    def batch(self, system_idx: torch.Tensor) -> None:
+        """Set the system indices from a batch index.
+
+        deprecated::
+            Use :attr:`system_idx` instead.
+        """
+        self.system_idx = system_idx
+
+    @property
     def n_batches(self) -> int:
-        """Number of batches in the system."""
-        return torch.unique(self.batch).shape[0]
+        """Number of batches in the system.
+
+        deprecated::
+            Use :attr:`n_systems` instead.
+        """
+        return self.n_systems
+
+    @property
+    def n_systems(self) -> int:
+        """Number of systems in the system."""
+        return torch.unique(self.system_idx).shape[0]
 
     @property
     def volume(self) -> torch.Tensor:
@@ -217,7 +258,7 @@ class SimState:
         """Convert the SimState to a list of ASE Atoms objects.
 
         Returns:
-            list[Atoms]: A list of ASE Atoms objects, one per batch
+            list[Atoms]: A list of ASE Atoms objects, one per system
         """
         return ts.io.state_to_atoms(self)
 
@@ -225,7 +266,7 @@ class SimState:
         """Convert the SimState to a list of pymatgen Structure objects.
 
         Returns:
-            list[Structure]: A list of pymatgen Structure objects, one per batch
+            list[Structure]: A list of pymatgen Structure objects, one per system
         """
         return ts.io.state_to_structures(self)
 
@@ -233,43 +274,43 @@ class SimState:
         """Convert the SimState to a list of PhonopyAtoms objects.
 
         Returns:
-            list[PhonopyAtoms]: A list of PhonopyAtoms objects, one per batch
+            list[PhonopyAtoms]: A list of PhonopyAtoms objects, one per system
         """
         return ts.io.state_to_phonopy(self)
 
     def split(self) -> list[Self]:
-        """Split the SimState into a list of single-batch SimStates.
+        """Split the SimState into a list of single-system SimStates.
 
-        Divides the current state into separate states, each containing a single batch,
-        preserving all properties appropriately for each batch.
+        Divides the current state into separate states, each containing a single system,
+        preserving all properties appropriately for each system.
 
         Returns:
-            list[SimState]: A list of SimState objects, one per batch
+            list[SimState]: A list of SimState objects, one per system
         """
         return _split_state(self)
 
-    def pop(self, batch_indices: int | list[int] | slice | torch.Tensor) -> list[Self]:
-        """Pop off states with the specified batch indices.
+    def pop(self, system_indices: int | list[int] | slice | torch.Tensor) -> list[Self]:
+        """Pop off states with the specified system indices.
 
         This method modifies the original state object by removing the specified
-        batches and returns the removed batches as separate SimState objects.
+        systems and returns the removed systems as separate SimState objects.
 
         Args:
-            batch_indices (int | list[int] | slice | torch.Tensor): The batch indices
+            system_indices (int | list[int] | slice | torch.Tensor): The system indices
                 to pop
 
         Returns:
-            list[SimState]: Popped SimState objects, one per batch index
+            list[SimState]: Popped SimState objects, one per system index
 
         Notes:
             This method modifies the original SimState in-place.
         """
-        batch_indices = _normalize_batch_indices(
-            batch_indices, self.n_batches, self.device
+        system_indices = _normalize_system_indices(
+            system_indices, self.n_systems, self.device
         )
 
         # Get the modified state and popped states
-        modified_state, popped_states = _pop_states(self, batch_indices)
+        modified_state, popped_states = _pop_states(self, system_indices)
 
         # Update all attributes of self with the modified state's attributes
         for attr_name, attr_value in vars(modified_state).items():
@@ -293,23 +334,23 @@ class SimState:
         """
         return state_to_device(self, device, dtype)
 
-    def __getitem__(self, batch_indices: int | list[int] | slice | torch.Tensor) -> Self:
+    def __getitem__(self, system_indices: int | list[int] | slice | torch.Tensor) -> Self:
         """Enable standard Python indexing syntax for slicing batches.
 
         Args:
-            batch_indices (int | list[int] | slice | torch.Tensor): The batch indices
+            system_indices (int | list[int] | slice | torch.Tensor): The system indices
                 to include
 
         Returns:
-            SimState: A new SimState containing only the specified batches
+            SimState: A new SimState containing only the specified systems
         """
         # TODO: need to document that slicing is supported
         # Reuse the existing slice method
-        batch_indices = _normalize_batch_indices(
-            batch_indices, self.n_batches, self.device
+        system_indices = _normalize_system_indices(
+            system_indices, self.n_systems, self.device
         )
 
-        return _slice_state(self, batch_indices)
+        return _slice_state(self, system_indices)
 
 
 class DeformGradMixin:
@@ -356,44 +397,44 @@ class DeformGradMixin:
         return self._deform_grad(self.reference_row_vector_cell, self.row_vector_cell)
 
 
-def _normalize_batch_indices(
-    batch_indices: int | list[int] | slice | torch.Tensor,
-    n_batches: int,
+def _normalize_system_indices(
+    system_indices: int | list[int] | slice | torch.Tensor,
+    n_systems: int,
     device: torch.device,
 ) -> torch.Tensor:
-    """Normalize batch indices to handle negative indices and different input types.
+    """Normalize system indices to handle negative indices and different input types.
 
-    Converts various batch index representations to a consistent tensor format,
+    Converts various system index representations to a consistent tensor format,
     handling negative indices in the Python style (counting from the end).
 
     Args:
-        batch_indices (int | list[int] | slice | torch.Tensor): The batch indices to
+        system_indices (int | list[int] | slice | torch.Tensor): The system indices to
             normalize
-        n_batches (int): Total number of batches in the system
+        n_systems (int): Total number of systems in the system
         device (torch.device): Device to place the output tensor on
 
     Returns:
-        torch.Tensor: Normalized batch indices as a tensor
+        torch.Tensor: Normalized system indices as a tensor
 
     Raises:
-        TypeError: If batch_indices is of an unsupported type
+        TypeError: If system_indices is of an unsupported type
     """
-    if isinstance(batch_indices, int):
+    if isinstance(system_indices, int):
         # Handle negative integer indexing
-        if batch_indices < 0:
-            batch_indices = n_batches + batch_indices
-        return torch.tensor([batch_indices], device=device)
-    if isinstance(batch_indices, list):
+        if system_indices < 0:
+            system_indices = n_systems + system_indices
+        return torch.tensor([system_indices], device=device)
+    if isinstance(system_indices, list):
         # Handle negative indices in lists
-        normalized = [idx if idx >= 0 else n_batches + idx for idx in batch_indices]
+        normalized = [idx if idx >= 0 else n_systems + idx for idx in system_indices]
         return torch.tensor(normalized, device=device)
-    if isinstance(batch_indices, slice):
+    if isinstance(system_indices, slice):
         # Let PyTorch handle the slice conversion with negative indices
-        return torch.arange(n_batches, device=device)[batch_indices]
-    if isinstance(batch_indices, torch.Tensor):
+        return torch.arange(n_systems, device=device)[system_indices]
+    if isinstance(system_indices, torch.Tensor):
         # Handle negative indices in tensors
-        return torch.where(batch_indices < 0, n_batches + batch_indices, batch_indices)
-    raise TypeError(f"Unsupported index type: {type(batch_indices)}")
+        return torch.where(system_indices < 0, n_systems + system_indices, system_indices)
+    raise TypeError(f"Unsupported index type: {type(system_indices)}")
 
 
 def state_to_device(
@@ -435,8 +476,8 @@ def state_to_device(
 def infer_property_scope(
     state: SimState,
     ambiguous_handling: Literal["error", "globalize", "globalize_warn"] = "error",
-) -> dict[Literal["global", "per_atom", "per_batch"], list[str]]:
-    """Infer whether a property is global, per-atom, or per-batch.
+) -> dict[Literal["global", "per_atom", "per_system"], list[str]]:
+    """Infer whether a property is global, per-atom, or per-system.
 
     Analyzes the shapes of tensor attributes to determine their scope within
     the atomistic system representation.
@@ -450,27 +491,27 @@ def infer_property_scope(
             - "globalize_warn": Treat ambiguous properties as global with a warning
 
     Returns:
-        dict[Literal["global", "per_atom", "per_batch"], list[str]]: Map of scope
+        dict[Literal["global", "per_atom", "per_system"], list[str]]: Map of scope
             category to list of property names
 
     Raises:
-        ValueError: If n_atoms equals n_batches (making scope inference ambiguous) or
+        ValueError: If n_atoms equals n_systems (making scope inference ambiguous) or
             if ambiguous_handling="error" and an ambiguous property is encountered
     """
     # TODO: this cannot effectively resolve global properties with
-    # length of n_atoms or n_batches, they will be classified incorrectly,
+    # length of n_atoms or n_systems, they will be classified incorrectly,
     # no clear fix
 
-    if state.n_atoms == state.n_batches:
+    if state.n_atoms == state.n_systems:
         raise ValueError(
-            f"n_atoms ({state.n_atoms}) and n_batches ({state.n_batches}) are equal, "
+            f"n_atoms ({state.n_atoms}) and n_systems ({state.n_systems}) are equal, "
             "which means shapes cannot be inferred unambiguously."
         )
 
     scope = {
         "global": [],
         "per_atom": [],
-        "per_batch": [],
+        "per_system": [],
     }
 
     # Iterate through all attributes
@@ -489,15 +530,15 @@ def infer_property_scope(
         # Vector/matrix with first dimension matching number of atoms
         elif shape[0] == state.n_atoms:
             scope["per_atom"].append(attr_name)
-        # Tensor with first dimension matching number of batches
-        elif shape[0] == state.n_batches:
-            scope["per_batch"].append(attr_name)
+        # Tensor with first dimension matching number of systems
+        elif shape[0] == state.n_systems:
+            scope["per_system"].append(attr_name)
         # Any other shape is ambiguous
         elif ambiguous_handling == "error":
             raise ValueError(
                 f"Cannot categorize property '{attr_name}' with shape {shape}. "
                 f"Expected first dimension to be either {state.n_atoms} (per-atom) or "
-                f"{state.n_batches} (per-batch), or a scalar (global)."
+                f"{state.n_systems} (per-system), or a scalar (global)."
             )
         elif ambiguous_handling in ("globalize", "globalize_warn"):
             scope["global"].append(attr_name)
@@ -516,10 +557,10 @@ def infer_property_scope(
 def _get_property_attrs(
     state: SimState, ambiguous_handling: Literal["error", "globalize"] = "error"
 ) -> dict[str, dict]:
-    """Get global, per-atom, and per-batch attributes from a state.
+    """Get global, per-atom, and per-system attributes from a state.
 
     Categorizes all attributes of the state based on their scope
-    (global, per-atom, or per-batch).
+    (global, per-atom, or per-system).
 
     Args:
         state (SimState): The state to extract attributes from
@@ -527,12 +568,12 @@ def _get_property_attrs(
             properties
 
     Returns:
-        dict[str, dict]: Keys are 'global', 'per_atom', and 'per_batch', each
+        dict[str, dict]: Keys are 'global', 'per_atom', and 'per_system', each
             containing a dictionary of attribute names to values
     """
     scope = infer_property_scope(state, ambiguous_handling=ambiguous_handling)
 
-    attrs = {"global": {}, "per_atom": {}, "per_batch": {}}
+    attrs = {"global": {}, "per_atom": {}, "per_system": {}}
 
     # Process global properties
     for attr_name in scope["global"]:
@@ -542,9 +583,9 @@ def _get_property_attrs(
     for attr_name in scope["per_atom"]:
         attrs["per_atom"][attr_name] = getattr(state, attr_name)
 
-    # Process per-batch properties
-    for attr_name in scope["per_batch"]:
-        attrs["per_batch"][attr_name] = getattr(state, attr_name)
+    # Process per-system properties
+    for attr_name in scope["per_system"]:
+        attrs["per_system"][attr_name] = getattr(state, attr_name)
 
     return attrs
 
@@ -552,19 +593,19 @@ def _get_property_attrs(
 def _filter_attrs_by_mask(
     attrs: dict[str, dict],
     atom_mask: torch.Tensor,
-    batch_mask: torch.Tensor,
+    system_mask: torch.Tensor,
 ) -> dict:
-    """Filter attributes by atom and batch masks.
+    """Filter attributes by atom and system masks.
 
-    Selects subsets of attributes based on boolean masks for atoms and batches.
+    Selects subsets of attributes based on boolean masks for atoms and systems.
 
     Args:
-        attrs (dict[str, dict]): Keys are 'global', 'per_atom', and 'per_batch', each
+        attrs (dict[str, dict]): Keys are 'global', 'per_atom', and 'per_system', each
             containing a dictionary of attribute names to values
         atom_mask (torch.Tensor): Boolean mask for atoms to include with shape
             (n_atoms,)
-        batch_mask (torch.Tensor): Boolean mask for batches to include with shape
-            (n_batches,)
+        system_mask (torch.Tensor): Boolean mask for systems to include with shape
+            (n_systems,)
 
     Returns:
         dict: Filtered attributes with appropriate handling for each scope
@@ -576,31 +617,31 @@ def _filter_attrs_by_mask(
 
     # Filter per-atom attributes
     for attr_name, attr_value in attrs["per_atom"].items():
-        if attr_name == "batch":
-            # Get the old batch indices for the selected atoms
-            old_batch = attr_value[atom_mask]
+        if attr_name == "system_idx":
+            # Get the old system indices for the selected atoms
+            old_system_idxs = attr_value[atom_mask]
 
-            # Get the batch indices that are kept
+            # Get the system indices that are kept
             kept_indices = torch.arange(attr_value.max() + 1, device=attr_value.device)[
-                batch_mask
+                system_mask
             ]
 
-            # Create a mapping from old batch indices to new consecutive indices
-            batch_map = {idx.item(): i for i, idx in enumerate(kept_indices)}
+            # Create a mapping from old system indices to new consecutive indices
+            system_idx_map = {idx.item(): i for i, idx in enumerate(kept_indices)}
 
-            # Create new batch tensor with remapped indices
-            new_batch = torch.tensor(
-                [batch_map[b.item()] for b in old_batch],
+            # Create new system tensor with remapped indices
+            new_system_idxs = torch.tensor(
+                [system_idx_map[b.item()] for b in old_system_idxs],
                 device=attr_value.device,
                 dtype=attr_value.dtype,
             )
-            filtered_attrs[attr_name] = new_batch
+            filtered_attrs[attr_name] = new_system_idxs
         else:
             filtered_attrs[attr_name] = attr_value[atom_mask]
 
-    # Filter per-batch attributes
-    for attr_name, attr_value in attrs["per_batch"].items():
-        filtered_attrs[attr_name] = attr_value[batch_mask]
+    # Filter per-system attributes
+    for attr_name, attr_value in attrs["per_system"].items():
+        filtered_attrs[attr_name] = attr_value[system_mask]
 
     return filtered_attrs
 
@@ -609,10 +650,10 @@ def _split_state(
     state: SimState,
     ambiguous_handling: Literal["error", "globalize"] = "error",
 ) -> list[SimState]:
-    """Split a SimState into a list of states, each containing a single batch element.
+    """Split a SimState into a list of states, each containing a single system.
 
-    Divides a multi-batch state into individual single-batch states, preserving
-    appropriate properties for each batch.
+    Divides a multi-system state into individual single-system states, preserving
+    appropriate properties for each system.
 
     Args:
         state (SimState): The SimState to split
@@ -623,37 +664,42 @@ def _split_state(
 
     Returns:
         list[SimState]: A list of SimState objects, each containing a single
-            batch element
+            system
     """
     attrs = _get_property_attrs(state, ambiguous_handling)
-    batch_sizes = torch.bincount(state.batch).tolist()
+    system_sizes = torch.bincount(state.system_idx).tolist()
 
-    # Split per-atom attributes by batch
+    # Split per-atom attributes by system
     split_per_atom = {}
     for attr_name, attr_value in attrs["per_atom"].items():
-        if attr_name == "batch":
+        if attr_name == "system_idx":
             continue
-        split_per_atom[attr_name] = torch.split(attr_value, batch_sizes, dim=0)
+        split_per_atom[attr_name] = torch.split(attr_value, system_sizes, dim=0)
 
-    # Split per-batch attributes into individual elements
-    split_per_batch = {}
-    for attr_name, attr_value in attrs["per_batch"].items():
-        split_per_batch[attr_name] = torch.split(attr_value, 1, dim=0)
+    # Split per-system attributes into individual elements
+    split_per_system = {}
+    for attr_name, attr_value in attrs["per_system"].items():
+        split_per_system[attr_name] = torch.split(attr_value, 1, dim=0)
 
-    # Create a state for each batch
+    # Create a state for each system
     states = []
-    for i in range(state.n_batches):
-        batch_attrs = {
-            # Create a batch tensor with all zeros for this batch
-            "batch": torch.zeros(batch_sizes[i], device=state.device, dtype=torch.int64),
+    for i in range(state.n_systems):
+        system_attrs = {
+            # Create a system tensor with all zeros for this system
+            "system_idx": torch.zeros(
+                system_sizes[i], device=state.device, dtype=torch.int64
+            ),
             # Add the split per-atom attributes
             **{attr_name: split_per_atom[attr_name][i] for attr_name in split_per_atom},
-            # Add the split per-batch attributes
-            **{attr_name: split_per_batch[attr_name][i] for attr_name in split_per_batch},
+            # Add the split per-system attributes
+            **{
+                attr_name: split_per_system[attr_name][i]
+                for attr_name in split_per_system
+            },
             # Add the global attributes
             **attrs["global"],
         }
-        states.append(type(state)(**batch_attrs))
+        states.append(type(state)(**system_attrs))
 
     return states
 
@@ -665,11 +711,11 @@ def _pop_states(
 ) -> tuple[SimState, list[SimState]]:
     """Pop off the states with the specified indices.
 
-    Extracts and removes the specified batch indices from the state.
+    Extracts and removes the specified system indices from the state.
 
     Args:
         state (SimState): The SimState to modify
-        pop_indices (list[int] | torch.Tensor): The batch indices to extract and remove
+        pop_indices (list[int] | torch.Tensor): The system indices to extract and remove
         ambiguous_handling ("error" | "globalize"): How to handle ambiguous
             properties. If "error", an error is raised if a property has ambiguous
             scope. If "globalize", properties with ambiguous scope are treated as
@@ -677,8 +723,8 @@ def _pop_states(
 
     Returns:
         tuple[SimState, list[SimState]]: A tuple containing:
-            - The modified original state with specified batches removed
-            - A list of the extracted SimStates, one per popped batch
+            - The modified original state with specified systems removed
+            - A list of the extracted SimStates, one per popped system
 
     Notes:
         Unlike the pop method, this function does not modify the input state.
@@ -691,17 +737,17 @@ def _pop_states(
 
     attrs = _get_property_attrs(state, ambiguous_handling)
 
-    # Create masks for the atoms and batches to keep and pop
-    batch_range = torch.arange(state.n_batches, device=state.device)
-    pop_batch_mask = torch.isin(batch_range, pop_indices)
-    keep_batch_mask = ~pop_batch_mask
+    # Create masks for the atoms and systems to keep and pop
+    system_range = torch.arange(state.n_systems, device=state.device)
+    pop_system_mask = torch.isin(system_range, pop_indices)
+    keep_system_mask = ~pop_system_mask
 
-    pop_atom_mask = torch.isin(state.batch, pop_indices)
+    pop_atom_mask = torch.isin(state.system_idx, pop_indices)
     keep_atom_mask = ~pop_atom_mask
 
     # Filter attributes for keep and pop states
-    keep_attrs = _filter_attrs_by_mask(attrs, keep_atom_mask, keep_batch_mask)
-    pop_attrs = _filter_attrs_by_mask(attrs, pop_atom_mask, pop_batch_mask)
+    keep_attrs = _filter_attrs_by_mask(attrs, keep_atom_mask, keep_system_mask)
+    pop_attrs = _filter_attrs_by_mask(attrs, pop_atom_mask, pop_system_mask)
 
     # Create the keep state
     keep_state = type(state)(**keep_attrs)
@@ -715,17 +761,17 @@ def _pop_states(
 
 def _slice_state(
     state: SimState,
-    batch_indices: list[int] | torch.Tensor,
+    system_indices: list[int] | torch.Tensor,
     ambiguous_handling: Literal["error", "globalize"] = "error",
 ) -> SimState:
-    """Slice a substate from the SimState containing only the specified batch indices.
+    """Slice a substate from the SimState containing only the specified system indices.
 
-    Creates a new SimState containing only the specified batches, preserving
+    Creates a new SimState containing only the specified systems, preserving
     all relevant properties.
 
     Args:
         state (SimState): The state to slice
-        batch_indices (list[int] | torch.Tensor): Batch indices to include in the
+        system_indices (list[int] | torch.Tensor): System indices to include in the
             sliced state
         ambiguous_handling ("error" | "globalize"): How to handle ambiguous
             properties. If "error", an error is raised if a property has ambiguous
@@ -733,28 +779,28 @@ def _slice_state(
             global.
 
     Returns:
-        SimState: A new SimState object containing only the specified batches
+        SimState: A new SimState object containing only the specified systems
 
     Raises:
-        ValueError: If batch_indices is empty
+        ValueError: If system_indices is empty
     """
-    if isinstance(batch_indices, list):
-        batch_indices = torch.tensor(
-            batch_indices, device=state.device, dtype=torch.int64
+    if isinstance(system_indices, list):
+        system_indices = torch.tensor(
+            system_indices, device=state.device, dtype=torch.int64
         )
 
-    if len(batch_indices) == 0:
-        raise ValueError("batch_indices cannot be empty")
+    if len(system_indices) == 0:
+        raise ValueError("system_indices cannot be empty")
 
     attrs = _get_property_attrs(state, ambiguous_handling)
 
-    # Create masks for the atoms and batches to include
-    batch_range = torch.arange(state.n_batches, device=state.device)
-    batch_mask = torch.isin(batch_range, batch_indices)
-    atom_mask = torch.isin(state.batch, batch_indices)
+    # Create masks for the atoms and systems to include
+    system_range = torch.arange(state.n_systems, device=state.device)
+    system_mask = torch.isin(system_range, system_indices)
+    atom_mask = torch.isin(state.system_idx, system_indices)
 
     # Filter attributes
-    filtered_attrs = _filter_attrs_by_mask(attrs, atom_mask, batch_mask)
+    filtered_attrs = _filter_attrs_by_mask(attrs, atom_mask, system_mask)
 
     # Create the sliced state
     return type(state)(**filtered_attrs)
@@ -765,8 +811,8 @@ def concatenate_states(
 ) -> SimState:
     """Concatenate a list of SimStates into a single SimState.
 
-    Combines multiple states into a single state with multiple batches.
-    Global properties are taken from the first state, and per-atom and per-batch
+    Combines multiple states into a single state with multiple systems.
+    Global properties are taken from the first state, and per-atom and per-system
     properties are concatenated.
 
     Args:
@@ -775,7 +821,7 @@ def concatenate_states(
             Defaults to the device of the first state.
 
     Returns:
-        SimState: A new SimState containing all input states as separate batches
+        SimState: A new SimState containing all input states as separate systems
 
     Raises:
         ValueError: If states is empty
@@ -796,20 +842,20 @@ def concatenate_states(
     target_device = device or first_state.device
 
     # Get property scopes from the first state to identify
-    # global/per-atom/per-batch properties
+    # global/per-atom/per-system properties
     first_scope = infer_property_scope(first_state)
     global_props = set(first_scope["global"])
     per_atom_props = set(first_scope["per_atom"])
-    per_batch_props = set(first_scope["per_batch"])
+    per_system_props = set(first_scope["per_system"])
 
     # Initialize result with global properties from first state
     concatenated = {prop: getattr(first_state, prop) for prop in global_props}
 
     # Pre-allocate lists for tensors to concatenate
     per_atom_tensors = {prop: [] for prop in per_atom_props}
-    per_batch_tensors = {prop: [] for prop in per_batch_props}
-    new_batch_indices = []
-    batch_offset = 0
+    per_system_tensors = {prop: [] for prop in per_system_props}
+    new_system_indices = []
+    system_offset = 0
 
     # Process all states in a single pass
     for state in states:
@@ -822,28 +868,28 @@ def concatenate_states(
             # if hasattr(state, prop):
             per_atom_tensors[prop].append(getattr(state, prop))
 
-        # Collect per-batch properties
-        for prop in per_batch_props:
+        # Collect per-system properties
+        for prop in per_system_props:
             # if hasattr(state, prop):
-            per_batch_tensors[prop].append(getattr(state, prop))
+            per_system_tensors[prop].append(getattr(state, prop))
 
-        # Update batch indices
-        num_batches = state.n_batches
-        new_indices = state.batch + batch_offset
-        new_batch_indices.append(new_indices)
-        batch_offset += num_batches
+        # Update system indices
+        num_systems = state.n_systems
+        new_indices = state.system_idx + system_offset
+        new_system_indices.append(new_indices)
+        system_offset += num_systems
 
     # Concatenate collected tensors
     for prop, tensors in per_atom_tensors.items():
         # if tensors:
         concatenated[prop] = torch.cat(tensors, dim=0)
 
-    for prop, tensors in per_batch_tensors.items():
+    for prop, tensors in per_system_tensors.items():
         # if tensors:
         concatenated[prop] = torch.cat(tensors, dim=0)
 
-    # Concatenate batch indices
-    concatenated["batch"] = torch.cat(new_batch_indices)
+    # Concatenate system indices
+    concatenated["system_idx"] = torch.cat(new_system_indices)
 
     # Create a new instance of the same class
     return state_class(**concatenated)
@@ -877,10 +923,10 @@ def initialize_state(
         return state_to_device(system, device, dtype)
 
     if isinstance(system, list) and all(isinstance(s, SimState) for s in system):
-        if not all(state.n_batches == 1 for state in system):
+        if not all(state.n_systems == 1 for state in system):
             raise ValueError(
                 "When providing a list of states, to the initialize_state function, "
-                "all states must have n_batches == 1. To fix this, you can split the "
+                "all states must have n_systems == 1. To fix this, you can split the "
                 "states into individual states with the split_state function."
             )
         return concatenate_states(system)

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -169,6 +169,11 @@ class SimState:
         deprecated::
             Use :attr:`n_atoms_per_system` instead.
         """
+        warnings.warn(
+            "n_atoms_per_batch is deprecated, use n_atoms_per_system instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.n_atoms_per_system
 
     @property
@@ -178,6 +183,11 @@ class SimState:
         deprecated::
             Use :attr:`system_idx` instead.
         """
+        warnings.warn(
+            "batch is deprecated, use system_idx instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.system_idx
 
     @batch.setter
@@ -187,6 +197,11 @@ class SimState:
         deprecated::
             Use :attr:`system_idx` instead.
         """
+        warnings.warn(
+            "Setting batch is deprecated, use system_idx instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.system_idx = system_idx
 
     @property
@@ -196,6 +211,11 @@ class SimState:
         deprecated::
             Use :attr:`n_systems` instead.
         """
+        warnings.warn(
+            "n_batches is deprecated, use n_systems instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.n_systems
 
     @property

--- a/torch_sim/typing.py
+++ b/torch_sim/typing.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 MemoryScaling = Literal["n_atoms_x_density", "n_atoms"]
-StateKey = Literal["positions", "masses", "cell", "pbc", "atomic_numbers", "batch"]
+StateKey = Literal["positions", "masses", "cell", "pbc", "atomic_numbers", "system_idx"]
 StateDict = dict[StateKey, torch.Tensor]
 SimStateVar = TypeVar("SimStateVar", bound="SimState")
 

--- a/torch_sim/workflows/a2c.py
+++ b/torch_sim/workflows/a2c.py
@@ -730,9 +730,9 @@ def get_unit_cell_relaxed_structure(
     device, dtype = model.device, model.dtype
 
     logger = {
-        "energy": torch.zeros((max_iter, state.n_batches), device=device, dtype=dtype),
+        "energy": torch.zeros((max_iter, state.n_systems), device=device, dtype=dtype),
         "stress": torch.zeros(
-            (max_iter, state.n_batches, 3, 3), device=device, dtype=dtype
+            (max_iter, state.n_systems, 3, 3), device=device, dtype=dtype
         ),
     }
 


### PR DESCRIPTION
## Summary

* The usage of the word "batch" is misleading since it really means "sample in a set of systems". Describing multiple systems as a set of systems is so much clearer. By renaming batch to system, we also free up the word "batch" to mean an actual batch (e.g. a **set** of systems we are processing at once)
* See https://github.com/Radical-AI/torch-sim/pull/189/files for more discussion.

This change is quite involved. But I didn't want to split it up into multiple parts because "batch" is so pervasive within the codebase. But it feels like the right thing to do. Notable, I changed these interfaces in the SimState:

```
SimState.n_atoms_per_batch (renamed to n_atoms_per_system)
SimState.n_batches (renamed to n_systems)
SimState.batch (renamed to system_idx)
SimState.__getitem__(self, batch_indices: int | list[int] | slice | torch.Tensor) -> Self: (renamed to SimState.__getitem__(self, system_indices: int | list[int] | slice | torch.Tensor) -> Self:)
SimState.__init__(self, ..., batch) (renamed to SimState.__init__(self, ..., system_idx))
```

The changes to getitem and init will cause breaking changes, but I feel like it is worth it while torchsim's adoption is currently minimal.

I have also bumped the minor version from 0.2.2 to 0.3.0

### Notes of my changes

* I didn't change the autobatcher logic much since it's a bit more involved and would probably require a more experienced eye to properly rename it.
* comments that are talking about the "batch dimension" have not been changed. This already makes sense because the system dimension IS the batch dimension.
* I probably did not get every rename. But the vast majority have been renamed.
* One way to review this PR is to clone it and search for "batch". Here, you can see the things that did NOT get renamed (and the surrounding code that did)
* [codecov/patch](https://github.com/Radical-AI/torch-sim/pull/216/checks?check_run_id=45503085521) is failing becuase this is just a huge change. However, I do not want to introduce logical changes in this PR so I'm not fixing it (it'll make it harder to review)
* http://test_graphpes.py/ failing is probably a flake


Note: this PR is an improved version of this PR: https://github.com/Radical-AI/torch-sim/pull/216 (with Rhys' suggestions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * All references to "batch" and related variables have been renamed to "system" or "system_idx" throughout the codebase, including in models, integrators, optimizers, state management, IO, transforms, neighbors, Monte Carlo, and tests.
  * Function signatures, class attributes, and internal variable names updated to use "system" terminology consistently.
  * Updated indexing and tensor shape annotations from batch-based to system-based dimensions.
  * Error messages, comments, and print statements revised to reflect "system" terminology.

* **Documentation**
  * Docstrings, comments, tutorials, and examples updated to replace "batch" with "system" for clarity and consistency.

* **Tests**
  * Test code and assertions modified to use "system" or "system_idx" terminology.
  * Renamed test functions and updated test fixtures to align with system-based naming.

* **Chores**
  * Updated `.gitignore` to exclude `.vscode/` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->