### PR TITLE
Fix concatenation of states in `InFlightAutoBatcher`

### DIFF
--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -490,7 +490,7 @@ def test_in_flight_with_fire(
             break
 
         # run 10 steps, arbitrary number
-        for _ in range(10):
+        for _ in range(5):
             state = fire_update(state)
         convergence_tensor = convergence_fn(state)
 


### PR DESCRIPTION
The `velocities` and `cell_velocities` are initialized to `None` in the `(FrechetCell)FIREState`. However, when using the `InFlightAutoBatcher` during an optimization, the current and new states are concatenated in `torch_sim.state.concatenate_states`. 

https://github.com/Radical-AI/torch-sim/blob/317985c731170aad578673ebe69a9334f5abe5be/torch_sim/state.py#L902-L909

When trying to merge states that were already processed for a few iterations (i.e., `velocities` are not `None` anymore) and newly initialized ones, an error is raised because the code tries to merge a `Tensor` with a `None`.

Here, I initialize the `(cell_)velocities` as tensors full of `nan` instead, so that one can merge already processed and newly initialized states. During the first initialization, the `fire` methods look for `nan` rows and replace them with zeros.


The error would also have been caught by the existing `test_autobatching` test if the number of iterations between swaps had been set to a smaller value (I changed it here). The reason is simply that within the current 10 iterations all states converge so that a completely new set of states is selected in the next iteration and already processed and newly initialised states never get merged.

You can either change the test as done here or use the following code snippet to reproduce the error with the current version:

<details>
<summary>Code to reproduce</summary>

```py
import torch_sim as ts
import torch
from torch_sim.autobatching import calculate_memory_scaler
from ase.build import bulk
from torch_sim.autobatching import estimate_max_memory_scaler
from mace.calculators.foundations_models import mace_mp
from torch_sim.models.mace import MaceModel


si_atoms = bulk("Si", "fcc", a=3.26, cubic=True)
si_atoms.rattle(0.05)

cu_atoms = bulk("Cu", "fcc", a=5.26, cubic=True)
cu_atoms.rattle(0.5)

many_cu_atoms = [si_atoms] * 5 + [cu_atoms] * 20

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
print(f"Using device: {device}")

state = ts.initialize_state(many_cu_atoms, device=device, dtype=torch.float64)

mace = mace_mp(model="small", return_raw_model=True)
mace_model = MaceModel(model=mace, device=device)

fire_init, fire_update = ts.optimizers.fire(mace_model)
fire_state = fire_init(state)

batcher = ts.InFlightAutoBatcher(
    model=mace_model,
    memory_scales_with="n_atoms",
    max_memory_scaler=40,
    max_iterations=10000,  # Optional: maximum convergence attempts per state
)

batcher.load_states(fire_state)

convergence_fn = ts.generate_force_convergence_fn(5e-3, include_cell_forces=False)

all_converged_states, convergence_tensor = [], None
while (result := batcher.next_batch(fire_state, convergence_tensor))[0] is not None:
    fire_state, converged_states = result
    all_converged_states.extend(converged_states)

    for _ in range(3):
        fire_state = fire_update(fire_state)

    convergence_tensor = convergence_fn(fire_state, None)
    print(f"Convergence tensor: {convergence_tensor}")
    print(f"Convergence tensor: {batcher.current_idx}")

else:
    all_converged_states.extend(result[1])

final_states = batcher.restore_original_order(all_converged_states)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of velocity initialization to ensure more robust and consistent behavior during optimization steps.

* **Tests**
  * Updated a test to reduce the number of simulation state updates for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->