### PR TITLE
add new states when the max_memory_scaler is updated

### DIFF
--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -952,6 +952,8 @@ class InFlightAutoBatcher:
                 scale_factor=self.memory_scaling_factor,
             )
             self.max_memory_scaler = self.max_memory_scaler * self.max_memory_padding
+            newer_states = self._get_next_states()
+            states = [*states, *newer_states]
         return concatenate_states([first_state, *states])
 
     def next_batch(  # noqa: C901


### PR DESCRIPTION
## Summary
This is related to the recent pull request #219. In addition to what @t-reents was suggesting, I found there is an improvement can be done in `InFlightAutoBatcher` during the initiation of batch. 
* The current batch initialization uses memory from the `first_state` to estimate the `max_memory_scaler`. After that, states are added using `states = self._get_next_states()`, based on the estimated `max_memory_scaler`. After this, `max_memory_scaler` is being estimated again using `estimate_max_memory_scaler`. This function results in a higher `max_memory_scaler`.  This means that more states can be added in the first batch.

What I added is these two lines:
```
newer_states = self._get_next_states()
states = [*states, *newer_states]
```
This allows more states to be added based on the new `max_memory_scaler` in the first batch. 

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced batching logic to include more states in the initial batch, potentially improving performance and efficiency for users processing large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->