### PR TITLE
Classify all variables of a SimState as per-node, per-system, and global features

### DIFF
--- a/examples/tutorials/state_tutorial.py
+++ b/examples/tutorials/state_tutorial.py
@@ -78,17 +78,7 @@ SimState attributes fall into three categories: atomwise, batchwise, and global.
 * Batchwise attributes are tensors with shape (n_systems, ...), this is just `cell` for
   the base SimState. Names are singular.
 * Global attributes have any other shape or type, just `pbc` here. Names are singular.
-
-You can use the `infer_property_scope` function to analyze a state's properties. This
-is mostly used internally but can be useful for debugging.
 """
-
-# %%
-from torch_sim.state import infer_property_scope
-
-scope = infer_property_scope(si_state)
-print(scope)
-
 
 # %% [markdown]
 """
@@ -256,12 +246,7 @@ md_state = MDState(
     energy=torch.zeros((si_state.n_systems,), device=si_state.device),  # Initial 0 energy
 )
 
-print("MDState properties:")
-scope = infer_property_scope(md_state)
-print("Global properties:", scope["global"])
-print("Per-atom properties:", scope["per_atom"])
-print("Per-system properties:", scope["per_system"])
-
+print(md_state)
 
 # %% [markdown]
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "pymatgen>=2024.11.3",
     "pytest-cov>=6",
     "pytest>=8",
+    "pytest-xdist>=3.8.0"
 ]
 io = ["ase>=3.24", "phonopy>=2.37.0", "pymatgen>=2024.11.3"]
 mace = ["mace-torch>=0.3.12"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -13,7 +13,6 @@ from torch_sim.state import (
     _pop_states,
     _slice_state,
     concatenate_states,
-    infer_property_scope,
     initialize_state,
 )
 
@@ -22,40 +21,6 @@ if typing.TYPE_CHECKING:
     from ase import Atoms
     from phonopy.structure.atoms import PhonopyAtoms
     from pymatgen.core import Structure
-
-
-def test_infer_sim_state_property_scope(si_sim_state: ts.SimState) -> None:
-    """Test inference of property scope."""
-    scope = infer_property_scope(si_sim_state)
-    assert set(scope["global"]) == {"pbc"}
-    assert set(scope["per_atom"]) == {
-        "positions",
-        "masses",
-        "atomic_numbers",
-        "system_idx",
-    }
-    assert set(scope["per_system"]) == {"cell"}
-
-
-def test_infer_md_state_property_scope(si_sim_state: ts.SimState) -> None:
-    """Test inference of property scope."""
-    state = MDState(
-        **asdict(si_sim_state),
-        momenta=torch.randn_like(si_sim_state.positions),
-        forces=torch.randn_like(si_sim_state.positions),
-        energy=torch.zeros((1,)),
-    )
-    scope = infer_property_scope(state)
-    assert set(scope["global"]) == {"pbc"}
-    assert set(scope["per_atom"]) == {
-        "positions",
-        "masses",
-        "atomic_numbers",
-        "system_idx",
-        "forces",
-        "momenta",
-    }
-    assert set(scope["per_system"]) == {"cell", "energy"}
 
 
 def test_slice_substate(

--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -9,7 +9,6 @@ from torch_sim import transforms
 from torch_sim.state import SimState
 
 
-@dataclass
 class MDState(SimState):
     """State information for molecular dynamics simulations.
 
@@ -36,9 +35,54 @@ class MDState(SimState):
         dtype (torch.dtype): Data type of tensors
     """
 
-    momenta: torch.Tensor
-    energy: torch.Tensor
-    forces: torch.Tensor
+    def __init__(
+        self,
+        *,
+        momenta: torch.Tensor,
+        energy: torch.Tensor,
+        forces: torch.Tensor,
+        positions: torch.Tensor,
+        masses: torch.Tensor,
+        atomic_numbers: torch.Tensor,
+        cell: torch.Tensor,
+        pbc: bool,
+        system_idx: torch.Tensor | None = None,
+    ):
+        super().__init__(
+            positions=positions,
+            masses=masses,
+            atomic_numbers=atomic_numbers,
+            cell=cell,
+            pbc=pbc,
+            system_idx=system_idx,
+        )
+        self.node_features["momenta"] = momenta
+        self.node_features["energy"] = energy
+        self.node_features["forces"] = forces
+
+    @property
+    def momenta(self) -> torch.Tensor:
+        return self.node_features["momenta"]
+
+    @momenta.setter
+    def momenta(self, momenta: torch.Tensor) -> None:
+        self.node_features["momenta"] = momenta
+
+    @property
+    def energy(self) -> torch.Tensor:
+        return self.node_features["energy"]
+
+    @energy.setter
+    def energy(self, energy: torch.Tensor) -> None:
+        self.node_features["energy"] = energy
+
+    @property
+    def forces(self) -> torch.Tensor:
+        return self.node_features["forces"]
+
+    @forces.setter
+    def forces(self, forces: torch.Tensor) -> None:
+        self.node_features["forces"] = forces
 
     @property
     def velocities(self) -> torch.Tensor:

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -7,7 +7,7 @@ operations and conversion to/from various atomistic formats.
 import copy
 import importlib
 import warnings
-from typing import TYPE_CHECKING, Literal, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 import torch
 
@@ -76,9 +76,9 @@ class SimState:
         >>> cloned_state = state.clone()
     """
 
-    node_features: dict[str, torch.Tensor]
-    system_features: dict[str, torch.Tensor]
-    global_features: dict[str, torch.Tensor]
+    node_features: dict[str, Any]
+    system_features: dict[str, Any]
+    global_features: dict[str, Any]
 
     def __init__(
         self,
@@ -146,11 +146,12 @@ class SimState:
 
         if self.cell.shape[0] != self.n_systems:
             raise ValueError(
-                f"Cell must have shape (n_systems, 3, 3), got {self.cell.shape}"
+                f"Cell must have shape (n_systems, 3, 3): ({self.n_systems}, 3, 3)"
+                f"got {self.cell.shape}"
             )
 
     @classmethod
-    def from_features(cls, node_features: dict[str, torch.Tensor], system_features: dict[str, torch.Tensor], global_features: dict[str, torch.Tensor]) -> Self:
+    def from_features(cls, node_features: dict[str, Any], system_features: dict[str, Any], global_features: dict[str, Any]) -> Self:
         # TODO(curtis): investigate if there are system features?
         return cls(
             positions=node_features["positions"],

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -7,8 +7,7 @@ operations and conversion to/from various atomistic formats.
 import copy
 import importlib
 import warnings
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, Self
+from typing import TYPE_CHECKING, Literal, Self, TypeVar, cast
 
 import torch
 
@@ -22,7 +21,6 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-@dataclass
 class SimState:
     """State representation for atomistic systems with batched operations support.
 
@@ -81,11 +79,27 @@ class SimState:
     cell: torch.Tensor
     pbc: bool  # TODO: do all calculators support mixed pbc?
     atomic_numbers: torch.Tensor
-    system_idx: torch.Tensor | None = field(default=None, kw_only=True)
+    system_idx: torch.Tensor
 
-    def __post_init__(self) -> None:
-        """Validate and process the state after initialization."""
-        # data validation and fill system_idx
+    def __init__(
+        self,
+        positions: torch.Tensor,
+        masses: torch.Tensor,
+        atomic_numbers: torch.Tensor,
+        cell: torch.Tensor,
+        *,
+        pbc: bool,
+        system_idx: torch.Tensor | None = None,
+    ) -> None:
+        """Initialize the SimState."""
+        self.positions = positions
+        self.masses = masses
+        self.cell = cell
+        self.pbc = pbc
+        self.atomic_numbers = atomic_numbers
+
+        # Validate and process the state after initialization.
+        # data validation and fill batch
         # should make pbc a tensor here
         # if devices aren't all the same, raise an error, in a clean way
         devices = {
@@ -107,13 +121,13 @@ class SimState:
                 f"masses {shapes[1]}, atomic_numbers {shapes[2]}"
             )
 
-        if self.cell.ndim != 3 and self.system_idx is None:
+        if self.cell.ndim != 3 and system_idx is None:
             self.cell = self.cell.unsqueeze(0)
 
         if self.cell.shape[-2:] != (3, 3):
             raise ValueError("Cell must have shape (n_systems, 3, 3)")
 
-        if self.system_idx is None:
+        if system_idx is None:
             self.system_idx = torch.zeros(
                 self.n_atoms, device=self.device, dtype=torch.int64
             )
@@ -121,9 +135,10 @@ class SimState:
             # assert that system indices are unique consecutive integers
             # TODO(curtis): I feel like this logic is not reliable.
             # I'll come up with something better later.
-            _, counts = torch.unique_consecutive(self.system_idx, return_counts=True)
-            if not torch.all(counts == torch.bincount(self.system_idx)):
+            _, counts = torch.unique_consecutive(system_idx, return_counts=True)
+            if not torch.all(counts == torch.bincount(system_idx)):
                 raise ValueError("System indices must be unique consecutive integers")
+            self.system_idx = system_idx
 
         if self.cell.shape[0] != self.n_systems:
             raise ValueError(
@@ -226,7 +241,9 @@ class SimState:
     @property
     def volume(self) -> torch.Tensor:
         """Volume of the system."""
-        return torch.det(self.cell) if self.pbc else None
+        if not self.pbc:
+            raise ValueError("Volume is only defined for periodic systems")
+        return torch.det(self.cell)
 
     @property
     def column_vector_cell(self) -> torch.Tensor:
@@ -336,7 +353,7 @@ class SimState:
         for attr_name, attr_value in vars(modified_state).items():
             setattr(self, attr_name, attr_value)
 
-        return popped_states
+        return cast("list[Self]", popped_states)
 
     def to(
         self, device: torch.device | None = None, dtype: torch.dtype | None = None
@@ -376,14 +393,8 @@ class SimState:
 class DeformGradMixin:
     """Mixin for states that support deformation gradients."""
 
-    @property
-    def momenta(self) -> torch.Tensor:
-        """Calculate momenta from velocities and masses.
-
-        Returns:
-            The momenta of the particles
-        """
-        return self.velocities * self.masses.unsqueeze(-1)
+    reference_cell: torch.Tensor
+    row_vector_cell: torch.Tensor
 
     @property
     def reference_row_vector_cell(self) -> torch.Tensor:
@@ -457,11 +468,14 @@ def _normalize_system_indices(
     raise TypeError(f"Unsupported index type: {type(system_indices)}")
 
 
+SimStateT = TypeVar("SimStateT", bound=SimState)
+
+
 def state_to_device(
-    state: SimState,
+    state: SimStateT,
     device: torch.device | None = None,
     dtype: torch.dtype | None = None,
-) -> Self:
+) -> SimStateT:
     """Convert the SimState to a new device and dtype.
 
     Creates a new SimState with all tensors moved to the specified device and
@@ -667,9 +681,9 @@ def _filter_attrs_by_mask(
 
 
 def _split_state(
-    state: SimState,
+    state: SimStateT,
     ambiguous_handling: Literal["error", "globalize"] = "error",
-) -> list[SimState]:
+) -> list[SimStateT]:
     """Split a SimState into a list of states, each containing a single system.
 
     Divides a multi-system state into individual single-system states, preserving
@@ -780,10 +794,10 @@ def _pop_states(
 
 
 def _slice_state(
-    state: SimState,
+    state: SimStateT,
     system_indices: list[int] | torch.Tensor,
     ambiguous_handling: Literal["error", "globalize"] = "error",
-) -> SimState:
+) -> SimStateT:
     """Slice a substate from the SimState containing only the specified system indices.
 
     Creates a new SimState containing only the specified systems, preserving
@@ -943,7 +957,7 @@ def initialize_state(
         return state_to_device(system, device, dtype)
 
     if isinstance(system, list) and all(isinstance(s, SimState) for s in system):
-        if not all(state.n_systems == 1 for state in system):
+        if not all(cast("SimState", state).n_systems == 1 for state in system):
             raise ValueError(
                 "When providing a list of states, to the initialize_state function, "
                 "all states must have n_systems == 1. To fix this, you can split the "


### PR DESCRIPTION
## Summary

This PR makes handling SimStates much simpler. Rather than guessing if an attribute is per-node/system/global, we just know. My solution is to use a dictionary to store **ALL** of a State's attributes:

```python
node_features: dict[str, torch.Tensor]
system_features: dict[str, torch.Tensor]
global_features: dict[str, torch.Tensor]
```

- Even states like cell/pbc/system_index etc. are stored inside these dictionaries. By not handling exceptions we make iterating through these properties much simpler.

For ease of access to these "standard" properties, I've added custom getters/setters for these properties:
```python
@property
def positions(self) -> torch.Tensor:
    return self.node_features["positions"]

@positions.setter
def positions(self, positions: torch.Tensor) -> None:
    self.node_features["positions"] = positions
```

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
