### PR TITLE
Make system_idx non-optional in `SimState` [1/2]

### DIFF
--- a/torch_sim/integrators/nvt.py
+++ b/torch_sim/integrators/nvt.py
@@ -389,6 +389,7 @@ def nvt_nose_hoover(
             cell=state.cell,
             pbc=state.pbc,
             atomic_numbers=atomic_numbers,
+            system_idx=state.system_idx,
             chain=chain_fns.initialize(total_dof, KE, kT),
             _chain_fns=chain_fns,  # Store the chain functions
         )

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -144,7 +144,7 @@ class SimState:
             if not torch.all(counts == torch.bincount(self.system_idx)):
                 raise ValueError("System indices must be unique consecutive integers")
 
-        if self.cell.ndim != 3 and self.system_idx is None:
+        if self.cell.ndim != 3 and system_idx is None:
             self.cell = self.cell.unsqueeze(0)
 
         if self.cell.shape[-2:] != (3, 3):

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -7,7 +7,7 @@ operations and conversion to/from various atomistic formats.
 import copy
 import importlib
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Self
 
 import torch
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-@dataclass
+@dataclass(init=False)
 class SimState:
     """State representation for atomistic systems with batched operations support.
 
@@ -47,9 +47,8 @@ class SimState:
             used by ASE.
         pbc (bool): Boolean indicating whether to use periodic boundary conditions
         atomic_numbers (torch.Tensor): Atomic numbers with shape (n_atoms,)
-        system_idx (torch.Tensor, optional): Maps each atom index to its system index.
-            Has shape (n_atoms,), defaults to None, must be unique consecutive
-            integers starting from 0
+        system_idx (torch.Tensor): Maps each atom index to its system index.
+            Has shape (n_atoms,), must be unique consecutive integers starting from 0.
 
     Properties:
         wrap_positions (torch.Tensor): Positions wrapped according to periodic boundary
@@ -81,10 +80,35 @@ class SimState:
     cell: torch.Tensor
     pbc: bool  # TODO: do all calculators support mixed pbc?
     atomic_numbers: torch.Tensor
-    system_idx: torch.Tensor | None = field(default=None, kw_only=True)
+    system_idx: torch.Tensor
 
-    def __post_init__(self) -> None:
-        """Validate and process the state after initialization."""
+    def __init__(
+        self,
+        positions: torch.Tensor,
+        masses: torch.Tensor,
+        cell: torch.Tensor,
+        pbc: bool,  # noqa: FBT001 # TODO(curtis): maybe make the constructor be keyword-only (it can be easy to confuse positions vs masses, etc.)
+        atomic_numbers: torch.Tensor,
+        system_idx: torch.Tensor | None = None,
+    ) -> None:
+        """Initialize the SimState and validate the arguments.
+
+        Args:
+            positions (torch.Tensor): Atomic positions with shape (n_atoms, 3)
+            masses (torch.Tensor): Atomic masses with shape (n_atoms,)
+            cell (torch.Tensor): Unit cell vectors with shape (n_systems, 3, 3).
+            pbc (bool): Boolean indicating whether to use periodic boundary conditions
+            atomic_numbers (torch.Tensor): Atomic numbers with shape (n_atoms,)
+            system_idx (torch.Tensor | None): Maps each atom index to its system index.
+                Has shape (n_atoms,), must be unique consecutive integers starting from 0.
+                If not provided, it is initialized to zeros.
+        """
+        self.positions = positions
+        self.masses = masses
+        self.cell = cell
+        self.pbc = pbc
+        self.atomic_numbers = atomic_numbers
+
         # data validation and fill system_idx
         # should make pbc a tensor here
         # if devices aren't all the same, raise an error, in a clean way
@@ -107,23 +131,24 @@ class SimState:
                 f"masses {shapes[1]}, atomic_numbers {shapes[2]}"
             )
 
-        if self.cell.ndim != 3 and self.system_idx is None:
-            self.cell = self.cell.unsqueeze(0)
-
-        if self.cell.shape[-2:] != (3, 3):
-            raise ValueError("Cell must have shape (n_systems, 3, 3)")
-
-        if self.system_idx is None:
+        if system_idx is None:
             self.system_idx = torch.zeros(
                 self.n_atoms, device=self.device, dtype=torch.int64
             )
         else:
+            self.system_idx = system_idx
             # assert that system indices are unique consecutive integers
             # TODO(curtis): I feel like this logic is not reliable.
             # I'll come up with something better later.
             _, counts = torch.unique_consecutive(self.system_idx, return_counts=True)
             if not torch.all(counts == torch.bincount(self.system_idx)):
                 raise ValueError("System indices must be unique consecutive integers")
+
+        if self.cell.ndim != 3 and self.system_idx is None:
+            self.cell = self.cell.unsqueeze(0)
+
+        if self.cell.shape[-2:] != (3, 3):
+            raise ValueError("Cell must have shape (n_systems, 3, 3)")
 
         if self.cell.shape[0] != self.n_systems:
             raise ValueError(


### PR DESCRIPTION
## Summary

This is part of my effort to type the codebase. system_idx is only optional during initialization so in the dataclass definition for `SimState`, I changed it from `system_idx: torch.Tensor | None` to `system_idx: torch.Tensor`

More importantly: This PR is the precursor to the one where I fix the SimState concatenation issue https://github.com/Radical-AI/torch-sim/pull/232 (because that PR has a check that disallows `torch.Tensor | None` attributes. By making system_idx non-optional, I can remove the `| None` in its definition

To also allow users to pass in a `None` `system_idx` in the constructor, I initialize the dataclass with `init=False` and wrote my own constructor for `SimState`

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the initialization and validation process for simulation state objects to enhance reliability while maintaining existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->